### PR TITLE
Create a build script that is ci specific

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ build: ## Create a production build
 	@echo "Creating production build."
 	@npm run build
 
+build-ci: ## Create a ci build
+	@echo "Creating a CI build"
+	@npm run build:ci
+	
 clean: ## Remove the build directory
 	@echo "Removing build directories."
 	@npm run clean

--- a/README.md
+++ b/README.md
@@ -3,22 +3,30 @@
 
 [![Netlify Status](https://api.netlify.com/api/v1/badges/9fff03eb-d9c8-48d1-887d-11aea21246cd/deploy-status)](https://app.netlify.com/sites/agingdeveloper/deploys)
 
-This is the personal site of Richard Klein. It is a static site built using [gatsby](https://www.gatsbyjs.org/) and [material-ui](https://material-ui.com). It is deployed via [netlify](https://www.netlify.com/). You can find a live version of it at [agingdeveloper.com](https://agingdeveloper.com/). The site is built based on the [Sky Lite theme](https://github.com/vim-labs/gatsby-theme-sky-lite) and expanded upon from there. See the [github issues](https://github.com/richwklein/agingdeveloper/issues) to track development progress.
+This is the personal site of Richard Klein. It is a static site built using [gatsby](https://www.gatsbyjs.org/) and 
+[material-ui](https://material-ui.com). It is deployed via [netlify](https://www.netlify.com/). You can find a live 
+version of it at [agingdeveloper.com](https://agingdeveloper.com/). The site is built based on the 
+[Sky Lite theme](https://github.com/vim-labs/gatsby-theme-sky-lite) and expanded upon from there. See the 
+[github issues](https://github.com/richwklein/agingdeveloper/issues) to track development progress.
 
 ## What's in This Document
   - [License](#license)
   - [Start local development](#start-local-development)
     - [Create a production build.](#create-a-production-build)
     - [Serve the production build locally.](#serve-the-production-build-locally)
-
+  - [vscode settings](#vscode-settings)
+  
 ## License
 - The site code is [MIT](/LICENSE) licensed 
 - The libraries the site is based upon are MIT licensed where feasible.
-- Content hosted on the site is [Creative Commons Attribution-ShareAlike 4.0 International](https://creativecommons.org/licenses/by-sa/4.0/) licensed unless otherwise noted.
+- Content hosted on the site is 
+- [Creative Commons Attribution-ShareAlike 4.0 International](https://creativecommons.org/licenses/by-sa/4.0/) 
+  licensed unless otherwise noted.
 
 ## Start local development
-Most javascript developers will likely already have the tools installed, but here is a quick rundown of setting things up just in case you do not. I'm using brew here since I develop on a Mac. Windows developers will have to use other package
-managers.
+Most javascript developers will likely already have the tools installed, but here is a quick rundown of setting things 
+up just in case you do not. I'm using brew here since I develop on a Mac. Windows developers will have to use other 
+package managers.
 
 1. **Install node and npm**
 
@@ -33,7 +41,7 @@ cd agingdeveloper/
 make install
 ```
 
-This will install local npm dependencies. It will install the "prettier" package globally.
+This will install local npm dependencies.
 
 1. **Start the development server**
 
@@ -49,7 +57,7 @@ Gatsby will start a hot-reloading development environment accessible by default 
 
 Try editing the JavaScript pages in src/pages. Saved changes will live reload in the browser.
 
-## Create a production build.
+## Create a build.
 
 ```cli
 make build
@@ -57,10 +65,36 @@ make build
 
 Gatsby will perform an optimized production build for your site, generating static HTML and per-route JavaScript code bundles.
 
-## Serve the production build locally.
+## Serve the build locally.
 
 ```cli
 make serve
 ```
 
 Gatsby starts a local HTML server for testing your built site. Remember to build your site using gatsby build before using this command.
+
+## Create a CI build
+
+```cli
+make build-ci
+```
+
+This will make sure source code is formatted, run tests, then create a build.
+
+## VSCode Settings
+
+VSCode is the main editor that is used on this site. ESLint is used for linting and formatting. 
+These settings enable a good workflow where lint issues are automatically corrected on save.
+
+```json
+{
+    "editor.tabCompletion": "on",
+    "editor.rulers": [80, 100, 120],
+    "editor.tabSize": 2,
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": true
+    },
+    "eslint.format.enable": true,
+    "eslint.lintTask.enable": true,
+}
+```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ version of it at [agingdeveloper.com](https://agingdeveloper.com/). The site is 
   - [Start local development](#start-local-development)
     - [Create a production build.](#create-a-production-build)
     - [Serve the production build locally.](#serve-the-production-build-locally)
-  - [vscode settings](#vscode-settings)
+  - [VSCode settings](#vscode-settings)
   
 ## License
 - The site code is [MIT](/LICENSE) licensed 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "version": "0.1.0",
   "scripts": {
     "build": "gatsby build",
+    "build:ci": "npm run format && npm run test && npm run build",
     "clean": "gatsby clean",
     "develop": "gatsby develop",
     "format": "eslint --fix 'src/**/*.{js,jsx}'",


### PR DESCRIPTION
Instead of using a git-hook for formatting I'm going to use a CI build command. This prevents developers from having to wait on builds during the commit phase, but will prevent the ci checks from passing if the format or unit tests are off.

Will resolve Issue #26 
 