### PR TITLE
Add view all and move around articles to permanent spot

### DIFF
--- a/content/article/2020/07/false-start.md
+++ b/content/article/2020/07/false-start.md
@@ -1,5 +1,5 @@
 ---
-url: "2020/07/26/false-start"
+url: "/article/2020/07/26/false-start"
 title: "Workflow, Tech Stack, and False Starts"
 author: richwklein
 image: ../../../image/braden-collum-9HI8UJMSdZA-unsplash.jpg

--- a/content/article/2020/07/intro.md
+++ b/content/article/2020/07/intro.md
@@ -1,5 +1,5 @@
 ---
-url: "2020/07/21/intro"
+url: "/article/2020/07/21/intro"
 title: "Introduction and Return"
 author: richwklein
 image: ../../../image/fons-heijnsbroek-v4c2gKPjPMs-unsplash.jpg

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -4,7 +4,6 @@ const path = require("path");
 exports.createPages = async ({actions, graphql, reporter}) => {
   const {createPage} = actions;
   const articleTemplate = path.resolve("src/templates/article.js");
-  const articlePathPrefix = "/article";
 
   const result = await graphql(`
     {
@@ -39,16 +38,16 @@ exports.createPages = async ({actions, graphql, reporter}) => {
     const previousPath =
       index === pages.length - 1 ?
         null :
-        `${articlePathPrefix}/${pages[index + 1].node.frontmatter.url}`;
+        `${pages[index + 1].node.frontmatter.url}`;
 
     // The path to the next page.
     const nextPath =
       index === 0 ?
         null :
-        `${articlePathPrefix}/${pages[index - 1].node.frontmatter.url}`;
+        `${pages[index - 1].node.frontmatter.url}`;
 
     return createPage({
-      path: `${articlePathPrefix}/${permalink}`,
+      path: `${permalink}`,
       component: articleTemplate,
       context: {
         permalink,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -4,7 +4,7 @@ const path = require("path");
 exports.createPages = async ({actions, graphql, reporter}) => {
   const {createPage} = actions;
   const articleTemplate = path.resolve("src/templates/article.js");
-  const articlePathPrefix = "/archive";
+  const articlePathPrefix = "/article";
 
   const result = await graphql(`
     {

--- a/src/components/ArticleCard.js
+++ b/src/components/ArticleCard.js
@@ -16,7 +16,15 @@ import {Launch} from "@material-ui/icons";
 
 const useStyles = makeStyles(() => ({
   card: {
-    maxWidth: 625,
+    "maxWidth": 625,
+
+    "& a": {
+      color: "inherit",
+      textDecoration: "none",
+    },
+    "& a:hover": {
+      textDecoration: "none",
+    },
   },
   cardImage: {
     maxWidth: 610,
@@ -37,7 +45,9 @@ const ArticleCard = ({image, title, date, excerpt, url}) => {
           />
         </Link>
       </CardMedia>
-      <CardHeader title={title} subheader={date} />
+      <Link to={url}>
+        <CardHeader title={title} subheader={date} />
+      </Link>
       <CardContent>
         <Typography variant="body2" color="textSecondary" component="p">
           {excerpt}

--- a/src/components/NavDrawer.js
+++ b/src/components/NavDrawer.js
@@ -73,6 +73,9 @@ const NavDrawer = ({open, onClose}) => {
       </Toolbar>
       <Divider />
       <NavList>
+        <NavItem label="Articles" to="/article/">
+          <Storage />
+        </NavItem>
         <NavItem label="Authors" to="/author/">
           <People />
         </NavItem>
@@ -81,9 +84,6 @@ const NavDrawer = ({open, onClose}) => {
         </NavItem>
         <NavItem label="Tags" to="/tag/">
           <LocalOffer />
-        </NavItem>
-        <NavItem label="Archive" to="/archive/">
-          <Storage />
         </NavItem>
       </NavList>
     </Drawer>

--- a/src/components/NavDrawer.js
+++ b/src/components/NavDrawer.js
@@ -76,14 +76,14 @@ const NavDrawer = ({open, onClose}) => {
         <NavItem label="Articles" to="/article/">
           <Storage />
         </NavItem>
-        <NavItem label="Authors" to="/author/">
-          <People />
-        </NavItem>
         <NavItem label="Categories" to="/category/">
           <Folder />
         </NavItem>
         <NavItem label="Tags" to="/tag/">
           <LocalOffer />
+        </NavItem>
+        <NavItem label="Authors" to="/author/">
+          <People />
         </NavItem>
       </NavList>
     </Drawer>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,13 +1,15 @@
 import React from "react";
-import {graphql} from "gatsby";
-import {Grid} from "@material-ui/core";
+import {graphql, Link} from "gatsby";
+import {Box, Button, Grid} from "@material-ui/core";
+import {Storage} from "@material-ui/icons";
+
 import ArticleCard from "../components/ArticleCard";
 import Banner from "../components/Banner";
 import Layout from "../components/Layout";
 import SEO from "../components/SEO";
 
 const ArticleGrid = ({articles}) => {
-  const articlePathPrefix = "/archive";
+  const articlePathPrefix = "/article";
 
   return (
     <Grid container spacing={3}>
@@ -53,6 +55,21 @@ const IndexPage = ({data}) => {
         url={`${siteUrl}/`}
         siteName={title} />
       <ArticleGrid articles={data.allMdx.edges} />
+      <Box
+        display="flex"
+        alignItems="center"
+        marginTop={2}
+        justifyContent="flex-end">
+        <Button
+          variant="contained"
+          color="secondary"
+          component={Link}
+          to={"/article/"}
+          startIcon={<Storage />}
+        >
+          View All
+        </Button>
+      </Box>
     </Layout>
   );
 };

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -9,8 +9,6 @@ import Layout from "../components/Layout";
 import SEO from "../components/SEO";
 
 const ArticleGrid = ({articles}) => {
-  const articlePathPrefix = "/article";
-
   return (
     <Grid container spacing={3}>
       {articles.map(
@@ -27,7 +25,7 @@ const ArticleGrid = ({articles}) => {
                   title={title}
                   date={date}
                   excerpt={excerpt}
-                  url={`${articlePathPrefix}/${url}`}
+                  url={url}
                 />
               </Grid>
             );

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -70,7 +70,7 @@ const ArticleTags = ({tags}) => {
 };
 
 const ArticlePage = ({data, pageContext}) => {
-  const pathPrefix = "archive";
+  const pathPrefix = "article";
   const classes = useStyles();
 
   const {


### PR DESCRIPTION
* Resolve #105 Add view all to home page. 
* Change the site layout so articles are under the "/article/" prefix instead of archive. 
* A follow up PR will need to be made to redirect the old urls before this goes live.
* Move around the navigation drawer so articles are at the top
* Make the title and subtitle of the article card link instead of just the image. 