### PR TITLE
Reorganize info

### DIFF
--- a/content/article/2020-07-21-intro/index.md
+++ b/content/article/2020-07-21-intro/index.md
@@ -1,5 +1,5 @@
 ---
-slug: "/2020/07/21/intro"
+slug: "2020-07-21-intro"
 title: "Introduction and Return"
 author: richwklein
 image: fons-heijnsbroek-v4c2gKPjPMs-unsplash.jpg

--- a/content/article/2020-07-26-false-start/index.md
+++ b/content/article/2020-07-26-false-start/index.md
@@ -1,5 +1,5 @@
 ---
-slug: "/2020/07/26/false-start"
+slug: "2020-07-26-false-start"
 title: "Workflow, Tech Stack, and False Starts"
 author: richwklein
 image: braden-collum-9HI8UJMSdZA-unsplash.jpg

--- a/content/article/2020-08-08-custom-domain/index.md
+++ b/content/article/2020-08-08-custom-domain/index.md
@@ -1,5 +1,5 @@
 ---
-slug: "/2020/08/08/custom-domain"
+slug: "2020-08-08-custom-domain"
 title: "Setting up a Custom Domain With Netlify"
 author: richwklein
 image: taylor-vick-M5tzZtFCOfs-unsplash.jpg

--- a/content/article/2020-08-14-default-http-config/index.md
+++ b/content/article/2020-08-14-default-http-config/index.md
@@ -1,5 +1,5 @@
 ---
-slug: "/2020/08/14/default-http-config"
+slug: "2020-08-14-default-http-config"
 title: "Default HTTP Config Considered Dangerous"
 author: richwklein
 image: israel-palacio-ImcUkZ72oUs-unsplash.jpg

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -64,7 +64,7 @@ exports.createPages = async ({actions, graphql, reporter}) => {
 
 
     return createPage({
-      path: `${articlePathPrefix}${currentPath}`,
+      path: `${articlePathPrefix}/${currentPath}`,
       component: articleTemplate,
       context: {
         currentPath,

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,5 +10,25 @@
   to = "/article/:splat"
   status = 302
 
-  [[plugins]]
+[[redirects]]
+  from = "/article/2020/08/14/default-http-config"
+  to = "/article/2020-08-14-default-http-config"
+  status = 302
+
+[[redirects]]
+  from = "/article/2020/08/08/custom-domain"
+  to = "/article/2020-08-08-custom-domain"
+  status = 302
+
+[[redirects]]
+  from = "/article/2020/07/26/false-start"
+  to = "/article/2020-07-26-false-start"
+  status = 302
+
+[[redirects]]
+  from = "/article/2020/07/21/intro"
+  to = "/article/2020-07-21-intro"
+  status = 302
+
+[[plugins]]
   package = "netlify-plugin-submit-sitemap"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "gatsby-source-filesystem": "^2.3.18",
     "gatsby-transformer-sharp": "^2.5.10",
     "has-scroll-hook": "^1.0.3",
-    "moment": "^2.27.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-helmet": "^6.1.0"

--- a/src/components/ArticleCard.js
+++ b/src/components/ArticleCard.js
@@ -34,7 +34,7 @@ const useStyles = makeStyles(() => ({
 
 const ArticleCard = ({image, title, date, excerpt, slug}) => {
   const classes = useStyles();
-  const url = "/article" + slug;
+  const url = "/article/" + slug;
 
   return (
     <Card variant="outlined" className={classes.card}>

--- a/src/components/ArticleGridList.js
+++ b/src/components/ArticleGridList.js
@@ -1,0 +1,36 @@
+import React from "react";
+
+import {
+  GridList,
+  GridListTile,
+} from "@material-ui/core";
+import ArticleCard from "../components/ArticleCard";
+
+const ArticleGridList = ({articles}) => {
+  return (
+    <GridList cellHeight={570} cols={2} spacing={24}>
+      {articles.map(
+          ({
+            node: {
+              excerpt,
+              frontmatter: {image, title, date, slug},
+            },
+          }) => {
+            return (
+              <GridListTile cols={1} key={slug}>
+                <ArticleCard
+                  image={image}
+                  title={title}
+                  date={date}
+                  excerpt={excerpt}
+                  slug={slug}
+                />
+              </GridListTile>
+            );
+          },
+      )}
+    </GridList>
+  );
+};
+
+export default ArticleGridList;

--- a/src/components/Banner.js
+++ b/src/components/Banner.js
@@ -1,5 +1,4 @@
 import React from "react";
-import clsx from "clsx";
 import {Avatar, Box, Typography} from "@material-ui/core";
 import {makeStyles} from "@material-ui/core/styles";
 import Img from "gatsby-image";
@@ -23,17 +22,9 @@ const useStyles = makeStyles((theme) => ({
     borderColor: theme.palette.secondary.light,
     borderStyle: "solid",
   },
-  avatarLarger: {
-    width: 256,
-    height: 256,
-    marginRight: theme.spacing(1),
-    borderWidth: 1,
-    borderColor: theme.palette.secondary.light,
-    borderStyle: "solid",
-  },
 }));
 
-const Banner = ({avatar, title, subtitle, children, largeAvatar = false}) => {
+const Banner = ({avatar, title, subtitle}) => {
   const classes = useStyles();
 
   return (
@@ -43,18 +34,15 @@ const Banner = ({avatar, title, subtitle, children, largeAvatar = false}) => {
           component={Img}
           fluid={avatar}
           loading="eager"
-          className={clsx(classes.avatar, {
-            [classes.avatarLarger]: largeAvatar,
-          })}
+          className={classes.avatar}
         />
-        <Box width="100%">
+        <Box width="100%" component="header">
           <Typography variant="h4" className={classes.bannerText}>
             {title}
           </Typography>
           <Typography variant="h6" className={classes.bannerText}>
             {subtitle}
           </Typography>
-          {children}
         </Box>
       </InnerBox>
     </Box>

--- a/src/components/ButtonGrid.js
+++ b/src/components/ButtonGrid.js
@@ -1,0 +1,45 @@
+
+import React from "react";
+import {Link} from "gatsby";
+import kebabCase from "lodash/kebabCase";
+import {Badge, Button, Grid} from "@material-ui/core";
+import {makeStyles} from "@material-ui/core/styles";
+
+const useStyles = makeStyles((theme) => ({
+  badge: {
+    position: "relative",
+    right: -4,
+    transform: "none",
+  },
+}));
+
+const ButtonGrid = ({group, pathPrefix}) => {
+  const classes=useStyles();
+
+  return (
+    <Grid container spacing={3}>
+      {group.map((item) => {
+        return (
+          <Grid item lg={2} md={3} sm={6} xs={12} key={item.fieldValue}>
+            <Button
+              color="primary"
+              variant="contained"
+              fullWidth
+              component={Link}
+              to={`${pathPrefix}/${kebabCase(item.fieldValue)}`}
+              endIcon={<Badge
+                badgeContent={item.totalCount}
+                color="secondary"
+                max={999}
+                overlap="rectangle"
+                classes={{anchorOriginTopRightRectangle: classes.badge}} />}>
+              {item.fieldValue}
+            </Button>
+          </Grid>
+        );
+      })}
+    </Grid>
+  );
+};
+
+export default ButtonGrid;

--- a/src/components/IconBanner.js
+++ b/src/components/IconBanner.js
@@ -31,7 +31,7 @@ const IconBanner = ({icon, title}) => {
         <Avatar className={classes.avatar} >
           {icon}
         </Avatar>
-        <Box width="100%">
+        <Box width="100%" component="header">
           <Typography variant="h4" className={classes.bannerText}>
             {title}
           </Typography>

--- a/src/components/TitleBanner.js
+++ b/src/components/TitleBanner.js
@@ -1,0 +1,31 @@
+import React from "react";
+import {Avatar, Box, Typography} from "@material-ui/core";
+import {makeStyles} from "@material-ui/core/styles";
+import InnerBox from "./InnerBox";
+
+const useStyles = makeStyles((theme) => ({
+  banner: {
+    color: theme.palette.primary.contrastText,
+    backgroundColor: theme.palette.primary.light,
+    padding: theme.spacing(2),
+  },
+  bannerText: {
+    marginLeft: 16, // aligns with content padding
+  },
+}));
+
+const TitleBanner = ({icon, title}) => {
+  const classes = useStyles();
+
+  return (
+    <Box className={classes.banner}>
+      <InnerBox display="flex" alignItems="center" component="header">
+        <Typography variant="h4" className={classes.bannerText}>
+          {title}
+        </Typography>
+      </InnerBox>
+    </Box>
+  );
+};
+
+export default TitleBanner;

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -17,7 +17,6 @@ const useStyles = makeStyles((theme) => ({
   header: {
     backgroundColor: theme.palette.primary.dark,
     color: theme.palette.primary.contrastText,
-    padding: theme.spacing(1),
   },
   title: {
     flexGrow: 1,

--- a/src/pages/category.js
+++ b/src/pages/category.js
@@ -1,67 +1,24 @@
 import React from "react";
-import {graphql, Link} from "gatsby";
-import {Badge, Button, Grid} from "@material-ui/core";
-import {makeStyles} from "@material-ui/core/styles";
+import {graphql} from "gatsby";
 
-import Layout from "../components/Layout";
 import {Helmet} from "react-helmet";
 import {Folder} from "@material-ui/icons";
-import kebabCase from "lodash/kebabCase";
+import ButtonGrid from "../components/ButtonGrid";
 import IconBanner from "../components/IconBanner";
-
-const useStyles = makeStyles((theme) => ({
-  badge: {
-    position: "relative",
-    right: -4,
-    transform: "none",
-  },
-}));
+import Layout from "../components/Layout";
 
 const CategoryHelmet = ({siteTitle}) => {
   return (<Helmet title={`Categories | ${siteTitle}`} />);
 };
 
-const CategoryGrid = ({categories}) => {
-  const classes=useStyles();
-
-  return (
-    <Grid container spacing={3}>
-      {categories.map((category) => {
-        return (
-          <Grid item lg={2} md={3} sm={6} xs={12} key={category.fieldValue}>
-            <Button
-              color="primary"
-              variant="contained"
-              fullWidth
-              component={Link}
-              to={`/category/${kebabCase(category.fieldValue)}`}
-              endIcon={<Badge
-                badgeContent={category.totalCount}
-                color="secondary"
-                max={999}
-                overlap="rectangle"
-                classes={{anchorOriginTopRightRectangle: classes.badge}} />}>
-              {category.fieldValue}
-            </Button>
-          </Grid>
-        );
-      })}
-    </Grid>
-  );
-};
-
-const categoryBanner = () => {
-  return <IconBanner icon={<Folder />} title="Categories" />;
-};
-
 const CategoryPage = ({data}) => {
   const {group: categories} = data.allMdx;
-  const banner = categoryBanner();
+  const banner = <IconBanner icon={<Folder />} title="Categories" />;
 
   return (
     <Layout showLogoImage={true} banner={banner}>
       <CategoryHelmet siteTitle={data.site.siteMetadata.title} />
-      <CategoryGrid categories={categories} />
+      <ButtonGrid group={categories} pathPrefix="/category" />
     </Layout>
   );
 };

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,48 +1,17 @@
 import React from "react";
 import {graphql, Link} from "gatsby";
-import {Box, Button, Grid} from "@material-ui/core";
+import {Box, Button} from "@material-ui/core";
 import {List as ListIcon} from "@material-ui/icons";
-
-import ArticleCard from "../components/ArticleCard";
+import ArticleGridList from "../components/ArticleGridList";
 import Banner from "../components/Banner";
 import Layout from "../components/Layout";
 import SEO from "../components/SEO";
 
-const ArticleGrid = ({articles}) => {
-  return (
-    <Grid container spacing={3}>
-      {articles.map(
-          ({
-            node: {
-              excerpt,
-              frontmatter: {image, title, date, slug},
-            },
-          }) => {
-            return (
-              <Grid item xs={12} sm={6} key={slug}>
-                <ArticleCard
-                  image={image}
-                  title={title}
-                  date={date}
-                  excerpt={excerpt}
-                  slug={slug}
-                />
-              </Grid>
-            );
-          },
-      )}
-    </Grid>
-  );
-};
-
-const indexBanner = ({avatar, title, subtitle}) => {
-  return <Banner avatar={avatar} title={title} subtitle={subtitle} />;
-};
 
 const IndexPage = ({data}) => {
   const avatar = data.file.childImageSharp.fluid;
   const {title, description: subtitle, siteUrl} = data.site.siteMetadata;
-  const banner = indexBanner({avatar, title, subtitle});
+  const banner = <Banner avatar={avatar} title={title} subtitle={subtitle} />;
 
   return (
     <Layout showLogoImage={false} banner={banner}>
@@ -52,7 +21,7 @@ const IndexPage = ({data}) => {
         image={`${siteUrl}${avatar.src}`}
         url={`${siteUrl}/`}
         siteName={title} />
-      <ArticleGrid articles={data.allMdx.edges} />
+      <ArticleGridList articles={data.allMdx.edges} />
       <Box
         display="flex"
         alignItems="center"

--- a/src/pages/tag.js
+++ b/src/pages/tag.js
@@ -1,67 +1,24 @@
 import React from "react";
-import {graphql, Link} from "gatsby";
-import {Badge, Button, Grid} from "@material-ui/core";
-import {makeStyles} from "@material-ui/core/styles";
+import {graphql} from "gatsby";
 
-import Layout from "../components/Layout";
 import {Helmet} from "react-helmet";
 import {LocalOffer} from "@material-ui/icons";
-import kebabCase from "lodash/kebabCase";
+import ButtonGrid from "../components/ButtonGrid";
 import IconBanner from "../components/IconBanner";
-
-const useStyles = makeStyles((theme) => ({
-  badge: {
-    position: "relative",
-    right: -4,
-    transform: "none",
-  },
-}));
+import Layout from "../components/Layout";
 
 const TagHelmet = ({siteTitle}) => {
   return (<Helmet title={`Tags | ${siteTitle}`} />);
 };
 
-const TagGrid = ({tags}) => {
-  const classes=useStyles();
-
-  return (
-    <Grid container spacing={3}>
-      {tags.map((tag) => {
-        return (
-          <Grid item lg={2} md={3} sm={6} xs={12} key={tag.fieldValue}>
-            <Button
-              color="primary"
-              variant="contained"
-              fullWidth
-              component={Link}
-              to={`/tag/${kebabCase(tag.fieldValue)}`}
-              endIcon={<Badge
-                badgeContent={tag.totalCount}
-                color="secondary"
-                max={999}
-                overlap="rectangle"
-                classes={{anchorOriginTopRightRectangle: classes.badge}} />}>
-              {tag.fieldValue}
-            </Button>
-          </Grid>
-        );
-      })}
-    </Grid>
-  );
-};
-
-const tagBanner = () => {
-  return <IconBanner icon={<LocalOffer />} title="Tags" />;
-};
-
 const TagPage = ({data}) => {
   const {group: tags} = data.allMdx;
-  const banner = tagBanner();
+  const banner = <IconBanner icon={<LocalOffer />} title="Tags" />;
 
   return (
     <Layout showLogoImage={true} banner={banner}>
       <TagHelmet siteTitle={data.site.siteMetadata.title} />
-      <TagGrid tags={tags} />
+      <ButtonGrid group={tags} pathPrefix="/tag" />
     </Layout>
   );
 };

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -7,7 +7,6 @@ import {
   Box,
   Button,
   Chip,
-  Typography,
 } from "@material-ui/core";
 import {makeStyles} from "@material-ui/styles";
 import {
@@ -18,6 +17,7 @@ import {
 import Layout from "../components/Layout";
 import SEO from "../components/SEO";
 import kebabCase from "lodash/kebabCase";
+import TitleBanner from "../components/TitleBanner";
 
 const useStyles = makeStyles((theme) => ({
 
@@ -36,13 +36,6 @@ const useStyles = makeStyles((theme) => ({
     maxWidth: 1264,
     maxHeight: 711,
   },
-  titleBox: {
-    marginBottom: theme.spacing(2),
-  },
-  title: {
-    fontFamily:
-      "Work Sans, -apple-system, BlinkMacSystemFont, Roboto, sans-serif",
-  },
   chip: {
     "padding": theme.spacing(0.5),
     "marginRight": theme.spacing(1),
@@ -55,18 +48,6 @@ const useStyles = makeStyles((theme) => ({
     borderBottomColor: theme.palette.secondary.main,
   },
 }));
-
-const ArticleTitle = ({title}) => {
-  const classes = useStyles();
-
-  return (
-    <header className={classes.titleBox}>
-      <Typography variant="h4" className={classes.title}>
-        {title}
-      </Typography>
-    </header>
-  );
-};
 
 const ArticleTags = ({category, tags}) => {
   const classes = useStyles();
@@ -112,11 +93,13 @@ const ArticleTemplate = ({data, pageContext}) => {
   const classes = useStyles();
 
   const {
-    frontmatter: {image, title, date, category, tags, slug},
+    frontmatter: {image, title, category, tags, slug},
     body,
   } = data.mdx;
   const {title: siteName, siteUrl} = data.site.siteMetadata;
   const {previousPath, nextPath} = pageContext;
+  const banner = <TitleBanner title={title} />;
+
   const disqusConfig = {
     url: `${siteUrl}/${slug}`,
     identifier: slug,
@@ -124,7 +107,7 @@ const ArticleTemplate = ({data, pageContext}) => {
   };
 
   return (
-    <Layout showLogoImage={true}>
+    <Layout showLogoImage={true} banner={banner} >
       <SEO
         title={title}
         description={title}
@@ -134,7 +117,6 @@ const ArticleTemplate = ({data, pageContext}) => {
         keywords={tags}
         isArticle={true} />
       <article className={classes.article}>
-        <ArticleTitle title={title} disqusConfig={disqusConfig} />
         <Img
           fluid={image.childImageSharp.fluid}
           style={{borderRadius: 6}}
@@ -186,7 +168,6 @@ export const pageQuery = graphql`
       frontmatter {
         slug
         title
-        date
         tags
         category
         image {

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -8,7 +8,6 @@ import {
   Button,
   Chip,
   Typography,
-  Breadcrumbs,
 } from "@material-ui/core";
 import {makeStyles} from "@material-ui/styles";
 import {
@@ -19,33 +18,9 @@ import {
 import Layout from "../components/Layout";
 import SEO from "../components/SEO";
 import kebabCase from "lodash/kebabCase";
-import moment from "moment";
 
 const useStyles = makeStyles((theme) => ({
-  breadcrumbs: {
-    "marginTop": -theme.spacing(1),
-    "marginBottom": theme.spacing(2),
-    "color": theme.palette.text.secondary,
-    "fontFamily": theme.typography.caption.fontFamily,
-    "fontSize": theme.typography.caption.fontSize,
-    "fontWeight": theme.typography.caption.fontWeight,
-    "lineHeight": theme.typography.caption.lineHeight,
 
-    "& a": {
-      color: "inherit",
-      textDecoration: "none",
-    },
-
-    "& a:hover": {
-      textDecoration: "underline",
-    },
-
-    "& a[disabled]": {
-      color: theme.palette.text.disabled,
-      textDecoration: "none",
-      cursor: "default",
-    },
-  },
   article: {
     "lineHeight": 1.6,
     "fontFamily": "Merriweather, sans-serif, serif",
@@ -80,38 +55,6 @@ const useStyles = makeStyles((theme) => ({
     borderBottomColor: theme.palette.secondary.main,
   },
 }));
-
-const ArtitleBreadcrumb = ({date, title, slug}) => {
-  const classes = useStyles();
-  const momentDate = moment(date);
-  const yearPath = "/article/" + momentDate.year();
-  const monthPath = yearPath + "/" + momentDate.format("MM");
-  const dayPath = monthPath + "/" + momentDate.format("DD");
-
-  return (
-    <Breadcrumbs separator="/" aria-label="breadcrumb"
-      className={classes.breadcrumbs} >
-      <Link to="/">
-        Home
-      </Link>
-      <Link to="/article">
-        Articles
-      </Link>
-      <Link to={yearPath}>
-        {momentDate.format("YYYY")}
-      </Link>
-      <Link to={monthPath} >
-        {momentDate.format("MMMM")}
-      </Link>
-      <Link to={dayPath} >
-        {momentDate.format("DD")}
-      </Link>
-      <Link to={`/article${slug}`} disabled>
-        {title}
-      </Link>
-    </Breadcrumbs>
-  );
-};
 
 const ArticleTitle = ({title}) => {
   const classes = useStyles();
@@ -165,7 +108,7 @@ const ArticleTags = ({category, tags}) => {
 };
 
 const ArticleTemplate = ({data, pageContext}) => {
-  const pathPrefix = "/article";
+  const pathPrefix = "/article/";
   const classes = useStyles();
 
   const {
@@ -190,7 +133,6 @@ const ArticleTemplate = ({data, pageContext}) => {
         siteName={siteName}
         keywords={tags}
         isArticle={true} />
-      <ArtitleBreadcrumb date={date} title={title} slug={slug} />
       <article className={classes.article}>
         <ArticleTitle title={title} disqusConfig={disqusConfig} />
         <Img

--- a/src/templates/category.js
+++ b/src/templates/category.js
@@ -1,16 +1,14 @@
 
 import React from "react";
 import {Helmet} from "react-helmet";
-import {graphql, Link} from "gatsby";
+import {graphql} from "gatsby";
 import {
-  Breadcrumbs,
   GridList,
   GridListTile,
   Typography,
 } from "@material-ui/core";
 import {makeStyles} from "@material-ui/styles";
 import Layout from "../components/Layout";
-import kebabCase from "lodash/kebabCase";
 import ArticleCard from "../components/ArticleCard";
 
 const capitalize = (category) => {
@@ -18,31 +16,6 @@ const capitalize = (category) => {
 };
 
 const useStyles = makeStyles((theme) => ({
-  breadcrumbs: {
-    "marginTop": -theme.spacing(1),
-    "marginBottom": theme.spacing(2),
-    "color": theme.palette.text.secondary,
-    "fontFamily": theme.typography.caption.fontFamily,
-    "fontSize": theme.typography.caption.fontSize,
-    "fontWeight": theme.typography.caption.fontWeight,
-    "lineHeight": theme.typography.caption.lineHeight,
-
-    "& a": {
-      color: "inherit",
-      textDecoration: "none",
-    },
-
-    "& a:hover": {
-      textDecoration: "underline",
-    },
-
-    "& a[disabled]": {
-      color: theme.palette.text.disabled,
-      textDecoration: "none",
-      cursor: "default",
-    },
-  },
-
   titleBox: {
     marginBottom: theme.spacing(2),
   },
@@ -66,26 +39,6 @@ const CategoryTitle = ({category}) => {
 
 const CategoryHelmet = ({category, siteTitle}) => {
   return (<Helmet title={`${capitalize(category)} | ${siteTitle}`} />);
-};
-
-const CategoryBreadcrumb = ({category}) => {
-  const classes = useStyles();
-
-  return (
-    <Breadcrumbs separator="/" aria-label="breadcrumb"
-      className={classes.breadcrumbs} >
-      <Link to="/">
-      Home
-      </Link>
-      <Link to="/category">
-      Categories
-      </Link>
-      <Link
-        to={`/category/${kebabCase(category)}`} disabled>
-        {capitalize(category)}
-      </Link>
-    </Breadcrumbs>
-  );
 };
 
 const ArticleGridList = ({articles}) => {
@@ -123,7 +76,6 @@ const CategoryTemplate = ({data, pageContext}) => {
       <CategoryHelmet
         category={category}
         siteTitle={data.site.siteMetadata.title} />
-      <CategoryBreadcrumb category={category} />
       <CategoryTitle category={category} />
       <ArticleGridList articles={data.allMdx.edges} />
     </Layout>

--- a/src/templates/category.js
+++ b/src/templates/category.js
@@ -2,81 +2,28 @@
 import React from "react";
 import {Helmet} from "react-helmet";
 import {graphql} from "gatsby";
-import {
-  GridList,
-  GridListTile,
-  Typography,
-} from "@material-ui/core";
-import {makeStyles} from "@material-ui/styles";
+import {Folder} from "@material-ui/icons";
+import ArticleGridList from "../components/ArticleGridList";
+import IconBanner from "../components/IconBanner";
 import Layout from "../components/Layout";
-import ArticleCard from "../components/ArticleCard";
 
 const capitalize = (category) => {
   return category.charAt(0).toUpperCase() + category.slice(1);
-};
-
-const useStyles = makeStyles((theme) => ({
-  titleBox: {
-    marginBottom: theme.spacing(2),
-  },
-  title: {
-    fontFamily:
-      "Work Sans, -apple-system, BlinkMacSystemFont, Roboto, sans-serif",
-  },
-}));
-
-const CategoryTitle = ({category}) => {
-  const classes = useStyles();
-
-  return (
-    <header className={classes.titleBox}>
-      <Typography variant="h4" className={classes.title}>
-        {capitalize(category)}
-      </Typography>
-    </header>
-  );
 };
 
 const CategoryHelmet = ({category, siteTitle}) => {
   return (<Helmet title={`${capitalize(category)} | ${siteTitle}`} />);
 };
 
-const ArticleGridList = ({articles}) => {
-  return (
-    <GridList cellHeight={570} cols={2} spacing={24}>
-      {articles.map(
-          ({
-            node: {
-              excerpt,
-              frontmatter: {image, title, date, slug},
-            },
-          }) => {
-            return (
-              <GridListTile cols={1} key={slug}>
-                <ArticleCard
-                  image={image}
-                  title={title}
-                  date={date}
-                  excerpt={excerpt}
-                  slug={slug}
-                />
-              </GridListTile>
-            );
-          },
-      )}
-    </GridList>
-  );
-};
-
 const CategoryTemplate = ({data, pageContext}) => {
   const category = pageContext.category;
+  const banner = <IconBanner icon={<Folder />} title={capitalize(category)} />;
 
   return (
-    <Layout showLogoImage={true}>
+    <Layout showLogoImage={true} banner={banner}>
       <CategoryHelmet
         category={category}
         siteTitle={data.site.siteMetadata.title} />
-      <CategoryTitle category={category} />
       <ArticleGridList articles={data.allMdx.edges} />
     </Layout>
   );

--- a/src/templates/tag.js
+++ b/src/templates/tag.js
@@ -1,16 +1,14 @@
 
 import React from "react";
 import {Helmet} from "react-helmet";
-import {graphql, Link} from "gatsby";
+import {graphql} from "gatsby";
 import {
-  Breadcrumbs,
   GridList,
   GridListTile,
   Typography,
 } from "@material-ui/core";
 import {makeStyles} from "@material-ui/styles";
 import Layout from "../components/Layout";
-import kebabCase from "lodash/kebabCase";
 import ArticleCard from "../components/ArticleCard";
 
 const capitalize = (tag) => {
@@ -18,31 +16,6 @@ const capitalize = (tag) => {
 };
 
 const useStyles = makeStyles((theme) => ({
-  breadcrumbs: {
-    "marginTop": -theme.spacing(1),
-    "marginBottom": theme.spacing(2),
-    "color": theme.palette.text.secondary,
-    "fontFamily": theme.typography.caption.fontFamily,
-    "fontSize": theme.typography.caption.fontSize,
-    "fontWeight": theme.typography.caption.fontWeight,
-    "lineHeight": theme.typography.caption.lineHeight,
-
-    "& a": {
-      color: "inherit",
-      textDecoration: "none",
-    },
-
-    "& a:hover": {
-      textDecoration: "underline",
-    },
-
-    "& a[disabled]": {
-      color: theme.palette.text.disabled,
-      textDecoration: "none",
-      cursor: "default",
-    },
-  },
-
   titleBox: {
     marginBottom: theme.spacing(2),
   },
@@ -66,25 +39,6 @@ const TagTitle = ({tag}) => {
 
 const TagHelmet = ({tag, siteTitle}) => {
   return (<Helmet title={`${capitalize(tag)} | ${siteTitle}`} />);
-};
-
-const TagBreadcrumb = ({tag}) => {
-  const classes = useStyles();
-
-  return (
-    <Breadcrumbs separator="/" aria-label="breadcrumb"
-      className={classes.breadcrumbs} >
-      <Link to="/">
-      Home
-      </Link>
-      <Link to="/tag">
-      Tags
-      </Link>
-      <Link to={`/tag/${kebabCase(tag)}`} disabled>
-        {capitalize(tag)}
-      </Link>
-    </Breadcrumbs>
-  );
 };
 
 const ArticleGridList = ({articles}) => {
@@ -120,7 +74,6 @@ const TagTemplate = ({data, pageContext}) => {
   return (
     <Layout showLogoImage={true}>
       <TagHelmet tag={tag} siteTitle={data.site.siteMetadata.title} />
-      <TagBreadcrumb tag={tag} />
       <TagTitle tag={tag} />
       <ArticleGridList articles={data.allMdx.edges} />
     </Layout>

--- a/src/templates/tag.js
+++ b/src/templates/tag.js
@@ -2,79 +2,27 @@
 import React from "react";
 import {Helmet} from "react-helmet";
 import {graphql} from "gatsby";
-import {
-  GridList,
-  GridListTile,
-  Typography,
-} from "@material-ui/core";
-import {makeStyles} from "@material-ui/styles";
+import {LocalOffer} from "@material-ui/icons";
+import ArticleGridList from "../components/ArticleGridList";
+import IconBanner from "../components/IconBanner";
 import Layout from "../components/Layout";
-import ArticleCard from "../components/ArticleCard";
 
 const capitalize = (tag) => {
   return tag.charAt(0).toUpperCase() + tag.slice(1);
-};
-
-const useStyles = makeStyles((theme) => ({
-  titleBox: {
-    marginBottom: theme.spacing(2),
-  },
-  title: {
-    fontFamily:
-      "Work Sans, -apple-system, BlinkMacSystemFont, Roboto, sans-serif",
-  },
-}));
-
-const TagTitle = ({tag}) => {
-  const classes = useStyles();
-
-  return (
-    <header className={classes.titleBox}>
-      <Typography variant="h4" className={classes.title}>
-        {capitalize(tag)}
-      </Typography>
-    </header>
-  );
 };
 
 const TagHelmet = ({tag, siteTitle}) => {
   return (<Helmet title={`${capitalize(tag)} | ${siteTitle}`} />);
 };
 
-const ArticleGridList = ({articles}) => {
-  return (
-    <GridList cellHeight={570} cols={2} spacing={24}>
-      {articles.map(
-          ({
-            node: {
-              excerpt,
-              frontmatter: {image, title, date, slug},
-            },
-          }) => {
-            return (
-              <GridListTile cols={1} key={slug}>
-                <ArticleCard
-                  image={image}
-                  title={title}
-                  date={date}
-                  excerpt={excerpt}
-                  slug={slug}
-                />
-              </GridListTile>
-            );
-          },
-      )}
-    </GridList>
-  );
-};
 
 const TagTemplate = ({data, pageContext}) => {
   const tag = pageContext.tag;
+  const banner = <IconBanner icon={<LocalOffer />} title={capitalize(tag)} />;
 
   return (
-    <Layout showLogoImage={true}>
+    <Layout showLogoImage={true} banner={banner}>
       <TagHelmet tag={tag} siteTitle={data.site.siteMetadata.title} />
-      <TagTitle tag={tag} />
       <ArticleGridList articles={data.allMdx.edges} />
     </Layout>
   );


### PR DESCRIPTION
Change our information layout so that we do not have to have pages for each day/month/year. This adds some redirects and removes the breadcrumbs. Also generalize a few components and switch to using the banner for title areas.