### PR TITLE
Opt the website out of floc

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,6 +10,11 @@
 [[plugins]]
   package = "netlify-plugin-submit-sitemap"
 
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Permissions-Policy = "interest-cohort=()"
+
 [[redirects]]
   from = "/archive/*"
   to = "/article/:splat"


### PR DESCRIPTION
Google recently announced the rollout of their Federated Learning of Cohorts (FLoC), a new advertising-surveillance initiative that seeks to replace third-party cookies with a new user profiling technique that garners data generated by the browser itself.

The EFF has written an overview of FLoC and it’s threats  and has also developed a useful tool  to test if a user’s browser is being used for data collection and fingerprinting.

Opt the site out of using cohorts. 

See https://github.com/w3c/webappsec-permissions-policy/blob/main/permissions-policy-explainer.md for an explanation of the header.

See https://paramdeo.com/blog/opting-your-website-out-of-googles-floc-network for the original article.

