### PR TITLE
Move redirects to a separate file

### DIFF
--- a/gatsby-node.mjs
+++ b/gatsby-node.mjs
@@ -1,5 +1,4 @@
 import {readFileSync} from "fs";
-import YAML from "js-yaml";
 import {resolve as pathResolve} from "path";
 import readingTime from "reading-time";
 import slug from "slug";

--- a/gatsby-node.mjs
+++ b/gatsby-node.mjs
@@ -1,3 +1,5 @@
+import {readFileSync} from "fs";
+import YAML from "js-yaml";
 import {resolve as pathResolve} from "path";
 import readingTime from "reading-time";
 import slug from "slug";
@@ -239,29 +241,12 @@ const createAuthorPages = (createPage, authors) => {
 };
 
 const createRedirects = (createRedirect) => {
-  createRedirect({
-    fromPath: "/article/rss-dead-long-live-rss",
-    toPath: "/article/2021-05-17-rss-dead-long-live-rss",
-    isPermanent: true,
-  });
-  createRedirect({
-    fromPath: "/article/2020/08/14/default-http-config",
-    toPath: "/article/2020-08-14-default-http-config",
-    isPermanent: true,
-  });
-  createRedirect({
-    fromPath: "/article/2020/08/08/custom-domain",
-    toPath: "/article/2020-08-08-custom-domain",
-    isPermanent: true,
-  });
-  createRedirect({
-    fromPath: "/article/2020/07/26/false-start",
-    toPath: "/article/2020-07-26-false-start",
-    isPermanent: true,
-  });
-  createRedirect({
-    fromPath: "/article/2020/07/21/intro",
-    toPath: "/article/2020-07-21-intro",
-    isPermanent: true,
-  });
+  const redirects = JSON.parse(readFileSync("redirects.json"));
+  redirects.forEach((redirect) =>
+    createRedirect({
+      fromPath: redirect.fromPath,
+      toPath: redirect.toPath,
+      isPermanent: redirect.isPermanent,
+    }),
+  );
 };

--- a/redirects.json
+++ b/redirects.json
@@ -1,0 +1,27 @@
+[
+  {
+    "fromPath":"/article/rss-dead-long-live-rss",
+    "toPath": "/article/2021-05-17-rss-dead-long-live-rss",
+    "isPermanent": true
+  },
+  {
+    "fromPath":"/article/2020/08/14/default-http-config",
+    "toPath": "/article/2020-08-14-default-http-config",
+    "isPermanent": true
+  },
+  {
+    "fromPath":"/article/2020/08/08/custoPathm-domain",
+    "toPath": "/article/2020-08-08-custoPathm-domain",
+    "isPermanent": true
+  },
+  {
+    "fromPath":"/article/2020/07/26/false-start",
+    "toPath": "/article/2020-07-26-false-start",
+    "isPermanent": true
+  },
+  {
+    "fromPath":"/article/2020/07/21/intro",
+    "toPath": "/article/2020-07-21-intro",
+    "isPermanent": true
+  }
+]


### PR DESCRIPTION
Move the redirects to a separate json file so that it isn't hardcoded in the gatsby-node.

fixes #578 