### PR TITLE
Fix where the page header overlaps content on small screens

### DIFF
--- a/src/components/InnerContainer.jsx
+++ b/src/components/InnerContainer.jsx
@@ -15,11 +15,11 @@ import {ChildrenProps} from "../props";
  *   <TagGrid tags={group} />
  * </InnerContainer>
  */
-export const InnerContainer = ({children, useMain=false}) => {
+export const InnerContainer = ({children, useMain=false, sx=null}) => {
   const component = useMain ? "main" : "div";
 
   return (
-    <Container maxWidth="lg" component={component}>
+    <Container maxWidth="lg" component={component} sx={sx}>
       {children}
     </Container>
   );
@@ -33,6 +33,16 @@ export const InnerContainer = ({children, useMain=false}) => {
 InnerContainer.propTypes = {
   children: ChildrenProps,
   useMain: PropTypes.bool,
+  sx: PropTypes.oneOfType([
+    PropTypes.arrayOf([
+      PropTypes.func,
+      PropTypes.object,
+      PropTypes.bool,
+    ]),
+    PropTypes.func,
+    PropTypes.object,
+  ],
+  ),
 };
 
 export default InnerContainer;

--- a/src/components/PageHeader.jsx
+++ b/src/components/PageHeader.jsx
@@ -17,14 +17,20 @@ import InternalLink from "./InternalLink";
 export const PageAvatar = ({image, title}) => {
   return (<Avatar
     variant="rounded"
-    sx={{
+    sx={(theme) => ({
       bgcolor: "primary.dark",
       borderWidth: 1,
       borderColor: "secondary.light",
       borderStyle: "solid",
-      width: "72px",
-      height: "72px",
-    }}>
+      [theme.breakpoints.up("sm")]: {
+        width: "72px",
+        height: "72px",
+      },
+      [theme.breakpoints.down("sm")]: {
+        width: "48px",
+        height: "48px",
+      },
+    })}>
     <GatsbyImage image={image} sx={{backgroundColor: "inherit"}} alt={title} />
   </Avatar>);
 };
@@ -65,7 +71,7 @@ export const PageHeader = ({title, tagline, avatar}) => {
       }}
     >
       <InnerContainer>
-        <Toolbar disableGutters>
+        <Toolbar disableGutters sx={{minWidth: "500px"}}>
           <ButtonBase component={InternalLink} to={"/"}
             sx={{color: "inherit", textDecoration: "none"}}>
             <PageAvatar image={avatar} title={title} />
@@ -73,7 +79,16 @@ export const PageHeader = ({title, tagline, avatar}) => {
               <Typography variant="h4" sx={{mb: 0.5}}>
                 {title}
               </Typography>
-              <Typography variant="h6" sx={{fontSize: "1rem", lineHeight: 1.4}}>
+              <Typography variant="h6" sx={(theme) => ({
+                fontSize: "1rem",
+                lineHeight: 1.4,
+                [theme.breakpoints.up("sm")]: {
+                  display: "block",
+                },
+                [theme.breakpoints.down("sm")]: {
+                  display: "none",
+                },
+              })}>
                 {tagline}
               </Typography>
             </Box>

--- a/src/components/PageLayout.jsx
+++ b/src/components/PageLayout.jsx
@@ -36,7 +36,14 @@ export const PageLayout = ({children}) => {
         tagline={tagline}
         avatar={avatar}
       />
-      <InnerContainer useMain={true}>
+      <InnerContainer useMain={true} sx={(theme) => ({
+        [theme.breakpoints.up("sm")]: {
+          paddingTop: 17,
+        },
+        [theme.breakpoints.down("sm")]: {
+          paddingTop: 15,
+        },
+      })}>
         {children}
       </InnerContainer>
       <ScrollTop />

--- a/src/components/__tests__/__snapshots__/PageHeader.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/PageHeader.test.jsx.snap
@@ -8,7 +8,7 @@ exports[`PageHeader that it renders correctly. 1`] = `
     class="MuiContainer-root MuiContainer-maxWidthLg css-1oqqzyl-MuiContainer-root"
   >
     <div
-      class="MuiToolbar-root MuiToolbar-regular css-r6ewbb-MuiToolbar-root"
+      class="MuiToolbar-root MuiToolbar-regular css-4o7ow2-MuiToolbar-root"
     >
       <a
         class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiButtonBase-root css-1hyky9h-MuiTypography-root-MuiLink-root-MuiButtonBase-root"
@@ -17,7 +17,7 @@ exports[`PageHeader that it renders correctly. 1`] = `
         tabindex="0"
       >
         <div
-          class="MuiAvatar-root MuiAvatar-rounded MuiAvatar-colorDefault css-1qmj1zq-MuiAvatar-root"
+          class="MuiAvatar-root MuiAvatar-rounded MuiAvatar-colorDefault css-bodjmb-MuiAvatar-root"
         />
         <div
           class="MuiBox-root css-d0uhtl"
@@ -28,7 +28,7 @@ exports[`PageHeader that it renders correctly. 1`] = `
             Test title
           </h4>
           <h6
-            class="MuiTypography-root MuiTypography-h6 css-1ry1zvy-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-h6 css-xoljz8-MuiTypography-root"
           >
             Test tagline is the best tagline
           </h6>

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -15,7 +15,6 @@ body,
 
 main {
   flex-grow: 1;
-  padding-top: 136px;
 }
 
 blockquote {


### PR DESCRIPTION
## Proposed changes

On small screens the header text wraps overlapping the body content. Add some theme breakpoints and hide the tagline when we are on a small screen.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Link to issue to close it

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
