### PR TITLE
Allow codecov from forks

### DIFF
--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -1,7 +1,8 @@
 name: "Coverage"
 on:
-    pull_request:
+    pull_request_target:
         branches:
+            - master
             - main
 
 jobs:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,5 +21,11 @@
     "agingdeveloper",
     "frontmatter",
     "pinterest"
-  ]
+  ],
+  "testing.openTesting": "neverOpen",
+  "jest.outputConfig": {
+    "revealOn": "run",
+    "revealWithFocus": "none",
+    "clearOnRun": "none"
+  }
 }


### PR DESCRIPTION
## Proposed changes
Switch when codecov runs so that forks can run code coverage. This means workflow changes will not take effect until they are merged into main.
