### PR TITLE
Split the coverage reporting from the testing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,10 +22,17 @@ updates:
           - 'eslint'
           - 'eslint-*'
           - '@eslint/*'
+          - 'typescript-eslint'
+          - '@typescript-eslint/*'
       prettier:
         patterns:
           - 'prettier'
           - 'prettier-*'
+      vitest:
+        patterns:
+          - 'vitest'
+          - 'vitest-*'
+          - '@vitest/*'
     schedule:
       interval: daily
     open-pull-requests-limit: 20

--- a/.github/workflows/code-test.yaml
+++ b/.github/workflows/code-test.yaml
@@ -1,4 +1,4 @@
-name: "Test"
+name: 'Test'
 on:
   pull_request:
 
@@ -9,14 +9,13 @@ jobs:
       matrix:
         branch:
           - ${{ github.head_ref }}
-          # TODO add main branch once this is merged - "main"
+          - 'main'
 
     permissions:
       contents: read
-      pull-requests: write
 
     steps:
-      - name: "Checkout source code"
+      - name: 'Checkout source code'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -27,20 +26,14 @@ jobs:
         with:
           node-version-file: '.tool-versions'
 
-      - name: "Install dependencies"
+      - name: 'Install dependencies'
         run: npm install
 
-      - name: "Run unit tests with coverage"
+      - name: 'Run unit tests with coverage'
         run: npm run coverage
 
-      - name: "Upload coverage report"
+      - name: 'Upload coverage report'
         uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ matrix.branch }}
           path: coverage
-
-      # TODO move reporting to a separate workflow (see https://github.com/marketplace/actions/vitest-coverage-report#working-with-pull-requests-from-forks)
-      - name: "Report coverage on pull request"
-        id: "coverage"
-        if: always()
-        uses: davelosert/vitest-coverage-report-action@v2

--- a/.github/workflows/report-coverage.yaml
+++ b/.github/workflows/report-coverage.yaml
@@ -1,0 +1,24 @@
+name: Report Coverage
+
+on:
+  workflow_run:
+    workflows: ['Test']
+    types:
+      - completed
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: 'Report Coverage'
+        uses: davelosert/vitest-coverage-report-action@v2

--- a/.github/workflows/report-coverage.yaml
+++ b/.github/workflows/report-coverage.yaml
@@ -1,4 +1,4 @@
-name: Report Coverage
+name: 'Report Coverage'
 
 on:
   workflow_run:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agingdeveloper",
   "private": true,
   "description": "The personal site of Richard Klein",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "type": "module",
   "scripts": {
     "dev": "npx astro dev",
@@ -28,7 +28,7 @@
     "@sindresorhus/slugify": "^2.2.1",
     "@tailwindcss/typography": "^0.5.13",
     "astro": "^4.12.2",
-    "astro-icon": "^1.1.0",
+    "astro-icon": "^1.1.1",
     "feed": "^4.2.2",
     "markdown-it": "^14.1.0",
     "mdast-util-to-string": "^4.0.0",
@@ -54,10 +54,5 @@
     "typescript": "^5.4.5",
     "typescript-eslint": "^8.1.0",
     "vitest": "^2.0.5"
-  },
-  "overrides": {
-    "astro-icon": {
-      "@iconify/tools": "^4.0.0"
-    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -54,5 +54,10 @@
     "typescript": "^5.4.5",
     "typescript-eslint": "^8.1.0",
     "vitest": "^2.0.5"
+  },
+  "overrides": {
+    "@typescript-eslint/utils": {
+      "eslint": "^9.9.0"
+    }
   }
 }


### PR DESCRIPTION
## Proposed changes

Split the coverage reporting into a separate workflow from the actual test. This allows coverage to be reported from forks. See https://github.com/richwklein/agingdeveloper/issues/587#issuecomment-2284372898

Also, bump the astro-icon version to fix #690 