### PR TITLE
Switch from overflow to scroll-gutter

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agingdeveloper",
   "private": true,
   "description": "The personal site of Richard Klein",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "type": "module",
   "scripts": {
     "dev": "npx astro dev",

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -16,8 +16,8 @@
 }
 
 html {
-  /* show scrollbar to prevent page jump */
-  overflow-y: scroll;
+  /* prevent page jump */
+  scrollbar-gutter: stable;
   min-height: 100vh;
 }
 


### PR DESCRIPTION
Switch from using an overflow-y to a scroll-gutter to prevent page jump when a scrollbar is needed. This fixes #699
