### PR TITLE
Add support for related articles

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agingdeveloper",
   "private": true,
   "description": "The personal site of Richard Klein",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "type": "module",
   "scripts": {
     "dev": "npx astro dev",

--- a/src/components/ArticleRelated.astro
+++ b/src/components/ArticleRelated.astro
@@ -1,0 +1,53 @@
+---
+/**
+ * @name ArticleRelated
+ * Component for showing the articles we consider related to the current one.
+ *
+ * @param {Props} props - The properties.
+ * @return {Function} an Astro component factory function.
+ *
+ * @example
+ * <ArticleRelated article={article}  />
+ */
+import LinkInternal from '@components/LinkInternal.astro'
+import { getRelatedArticles } from '@utils/article'
+import type { CollectionEntry } from 'astro:content'
+import { Icon } from 'astro-icon/components'
+
+interface Props {
+  article: CollectionEntry<'article'>
+  class?: string
+}
+
+const { article, class: className } = Astro.props
+const related = await getRelatedArticles(article, 5)
+---
+
+{
+  related.length == 0 ? null : (
+    <aside
+      class:list={['min-w-36 p-2', 'rounded-md border border-stone-500 p-2', className]}
+      aria-labelledby="related-articles"
+    >
+      <div class:list={['flex flex-row items-center gap-x-1']}>
+        <Icon class:list={['h-6 w-6']} name="mdi:link" />
+        <h4 id="related-articles" class:list={['text-md leading-relaxed']}>
+          Related Articles
+        </h4>
+      </div>
+      <nav>
+        <ol>
+          {related.map((matched) => (
+            <li>
+              <article class:list={['text-md pl-7']}>
+                <LinkInternal to={`/article/${matched.slug}`} class:list={['hover:underline']}>
+                  <h5 class:list={['text-md my-1 block']}>{matched.data.title}</h5>
+                </LinkInternal>
+              </article>
+            </li>
+          ))}
+        </ol>
+      </nav>
+    </aside>
+  )
+}

--- a/src/components/ArticleTimeToRead.astro
+++ b/src/components/ArticleTimeToRead.astro
@@ -3,8 +3,8 @@
  * @name ArticleTimeToRead
  * Component for showing the word count and time to read for an article.
  *
- * @param {ArticleTimeToReadProps} props - The article time to read props.
- * @return {React.ReactElement} - The react component
+ * @param {Props} props - The properties.
+ * @return {Function} an Astro component factory function.
  *
  * @example
  * <ArticleTimeToRead minutes={timeToRead.minutes} words={timeToRead.words}  />
@@ -23,10 +23,11 @@ const readTemplate = `${Math.ceil(minutes)} min read`
 const wordsTemplate = `${wordFormat} words`
 ---
 
-<div
+<aside
+  aria-label="Word Count"
   class:list={[
     'flex min-w-36 flex-row items-center gap-x-2',
-    'rounded-md border-2 border-primary-main p-1',
+    'rounded-md border border-stone-500 p-2',
     className,
   ]}
 >
@@ -35,4 +36,4 @@ const wordsTemplate = `${wordFormat} words`
     <small class:list={['text-sm']}>{readTemplate}</small>
     <small class:list={['text-sm']}>{wordsTemplate}</small>
   </div>
-</div>
+</aside>

--- a/src/content/article/2023/12-31-gatsby-rebuild/index.mdx
+++ b/src/content/article/2023/12-31-gatsby-rebuild/index.mdx
@@ -19,8 +19,11 @@ tags:
   - author
   - support
   - rebuild
+  - tech
+  - version
 category: code
-published: "2023-12-01"
+published: '2023-12-01'
+modified: '2024-08-18'
 ---
 
 I've previously wrote that [major versions should be considered harmful](/article/2022-02-26-major-harmful). I haven't done anything with this site in a long time partially because of that. Another reason is I wanted something where I could run a small amount of code on the front-end, but I wanted the majority of the site to be served statically. I do not mean pre-generating large amounts of javascript that then hydrates and renders the page client side. I wanted to generate actual html that is returned by the server and only have small amount of JavaScript for interactions. That has lead me to look at various other static site generators like **[astro](https://astro.build/)** and **[11ty](https://www.11ty.dev/)**. Astro's island architecture looked promising, but it was yet another framework and language to learn. 

--- a/src/content/article/2024/08-16-astro-launch/index.mdx
+++ b/src/content/article/2024/08-16-astro-launch/index.mdx
@@ -18,8 +18,11 @@ tags:
   - tailwind
   - test
   - rebuild
+  - tech
+  - version
 category: code
 published: '2024-08-16'
+modified: '2024-08-18'
 ---
 
 A few years ago, I started eyeing the framework [Astro](https://astro.build/), and it immediately caught my attention. When I refreshed the site last year by updating to a new version of [Gatsby](https://www.gatsbyjs.com/), I considered making the switch to Astro at that time. However, I decided against it, as it would require learning a new toolset, and I believed that Gatsby would offer an easier upgrade path and simpler long-term maintenance to keep the site running smoothly.

--- a/src/pages/article/[slug].astro
+++ b/src/pages/article/[slug].astro
@@ -4,6 +4,7 @@
  */
 import ArticleByLine from '@components/ArticleByLine.astro'
 import ArticleImage from '@components/ArticleImage.astro'
+import ArticleRelated from '@components/ArticleRelated.astro'
 import ArticleTagGrid from '@components/ArticleTagGrid.astro'
 import ArticleTimeToRead from '@components/ArticleTimeToRead.astro'
 import ArticleTitle from '@components/ArticleTitle.astro'
@@ -61,16 +62,17 @@ const { Content, remarkPluginFrontmatter: frontmatter } = await article.render()
     <ArticleByLine author={author} published={data.published} />
     <ArticleTitle title={data.title} description={data.description} class:list={['mt-4']} />
     <ArticleImage featured={data.featured} class:list={['mt-4']} />
-    <section class:list={['mt-4 grid grid-flow-row grid-cols-5 gap-x-4']}>
+    <section class:list={['mt-4 grid grid-flow-row grid-cols-6 gap-x-4']}>
       <div class:list={['prose col-span-4 max-w-none md:prose-lg lg:prose-xl']}>
         <Content components={{ a: LinkMDX }} />
       </div>
-      <aside>
+      <div class:list={['col-span-2']}>
         <ArticleTimeToRead
           minutes={frontmatter.readingTime.minutes}
           words={frontmatter.readingTime.words}
         />
-      </aside>
+        <ArticleRelated article={article} class:list={['mt-8']} />
+      </div>
     </section>
     <ArticleTagGrid category={data.category} tags={data.tags} class:list={['mt-4']} />
   </article>

--- a/src/pages/author/[slug].astro
+++ b/src/pages/author/[slug].astro
@@ -28,7 +28,7 @@ export async function getStaticPaths() {
   const site = await getSite()
   const authors = await getCollection('author')
 
-  const pages = authors.map((author) => {
+  const pages = authors.map((author: CollectionEntry<'author'>) => {
     return {
       params: { slug: slugify(author.id) },
       props: { author, site },
@@ -41,7 +41,7 @@ export async function getStaticPaths() {
 const { site, author } = Astro.props
 const limit = site.data.displayLimit
 const data = author.data
-const { entries: articleEntries, total } = await getArticlesByAuthor(author.id, limit)
+const { articles, total } = await getArticlesByAuthor(author.id, limit)
 const authorPath = Astro.url.pathname
 ---
 
@@ -92,7 +92,7 @@ const authorPath = Astro.url.pathname
       <SocialBar socials={data.socials} class:list={['mt-1: md:mt-2']} />
     </hgroup>
   </header>
-  <ArticleGrid articles={articleEntries} class:list={['mt-4']} />
-  <DisplayLimitAlert displayed={articleEntries.length} total={total} class:list={['mt-4']} />
+  <ArticleGrid articles={articles} class:list={['mt-4']} />
+  <DisplayLimitAlert displayed={articles.length} total={total} class:list={['mt-4']} />
   <BackLink class:list={['mt-4']} name={'authors'} to={'/author'} />
 </Layout>

--- a/src/pages/category/[slug].astro
+++ b/src/pages/category/[slug].astro
@@ -10,8 +10,9 @@ import BreadcrumbJson from '@components/seo/BreadcrumbJson.astro'
 import SeoBasic from '@components/seo/SeoBasic.astro'
 import Layout from '@layouts/Layout.astro'
 import slugify from '@sindresorhus/slugify'
-import { getArticlesByCategory, getCategories } from '@utils/article'
+import { getArticlesByCategory } from '@utils/article'
 import { getSite } from '@utils/site'
+import { getCategories } from '@utils/tag'
 import type { CollectionEntry } from 'astro:content'
 
 interface Props {
@@ -35,7 +36,7 @@ export async function getStaticPaths() {
 
 const { category, site } = Astro.props
 const limit = site.data.displayLimit
-const { entries, total } = await getArticlesByCategory(category, limit)
+const { articles, total } = await getArticlesByCategory(category, limit)
 const categoryPath = Astro.url.pathname
 ---
 
@@ -59,7 +60,7 @@ const categoryPath = Astro.url.pathname
     tail={category}
     class:list={['mb-4']}
   />
-  <ArticleGrid articles={entries} class:list={['mt-4']} />
-  <DisplayLimitAlert displayed={entries.length} total={total} class:list={['mt-4']} />
+  <ArticleGrid articles={articles} class:list={['mt-4']} />
+  <DisplayLimitAlert displayed={articles.length} total={total} class:list={['mt-4']} />
   <BackLink class:list={['mt-4']} name={'categories'} to={'/category'} />
 </Layout>

--- a/src/pages/category/index.astro
+++ b/src/pages/category/index.astro
@@ -7,11 +7,11 @@ import BreadcrumbJson from '@components/seo/BreadcrumbJson.astro'
 import SeoBasic from '@components/seo/SeoBasic.astro'
 import TagGrid from '@components/TagGrid.astro'
 import Layout from '@layouts/Layout.astro'
-import { getCategoriesWithCount } from '@utils/article'
 import { getSite } from '@utils/site'
+import { getCategoriesWithCount } from '@utils/tag'
 
 const site = await getSite()
-const { categories, total } = await getCategoriesWithCount()
+const { tags: categories, total } = await getCategoriesWithCount()
 const categoriesPath = Astro.url.pathname
 ---
 

--- a/src/pages/tag/[slug].astro
+++ b/src/pages/tag/[slug].astro
@@ -10,8 +10,9 @@ import BreadcrumbJson from '@components/seo/BreadcrumbJson.astro'
 import SeoBasic from '@components/seo/SeoBasic.astro'
 import Layout from '@layouts/Layout.astro'
 import slugify from '@sindresorhus/slugify'
-import { getArticlesByTag, getTags } from '@utils/article'
+import { getArticlesByTag } from '@utils/article'
 import { getSite } from '@utils/site'
+import { getTags } from '@utils/tag'
 import type { CollectionEntry } from 'astro:content'
 
 interface Props {
@@ -36,7 +37,7 @@ export async function getStaticPaths() {
 
 const { tag, site } = Astro.props
 const limit = site.data.displayLimit
-const { entries, total } = await getArticlesByTag(tag, limit)
+const { articles, total } = await getArticlesByTag(tag, limit)
 const tagPath = Astro.url.pathname
 ---
 
@@ -56,7 +57,7 @@ const tagPath = Astro.url.pathname
     />
   </Fragment>
   <BreadcrumbHeader head={{ name: 'Tags', path: '/tag' }} tail={tag} class:list={['mb-4']} />
-  <ArticleGrid articles={entries} class:list={['mt-4']} />
-  <DisplayLimitAlert displayed={entries.length} total={total} class:list={['mt-4']} />
+  <ArticleGrid articles={articles} class:list={['mt-4']} />
+  <DisplayLimitAlert displayed={articles.length} total={total} class:list={['mt-4']} />
   <BackLink class:list={['mt-4']} name={'tags'} to={'/tag'} />
 </Layout>

--- a/src/pages/tag/index.astro
+++ b/src/pages/tag/index.astro
@@ -7,8 +7,8 @@ import BreadcrumbJson from '@components/seo/BreadcrumbJson.astro'
 import SeoBasic from '@components/seo/SeoBasic.astro'
 import TagGrid from '@components/TagGrid.astro'
 import Layout from '@layouts/Layout.astro'
-import { getTagsWithCount } from '@utils/article'
 import { getSite } from '@utils/site'
+import { getTagsWithCount } from '@utils/tag'
 
 const site = await getSite()
 const { tags, total } = await getTagsWithCount()

--- a/src/utils/feed.ts
+++ b/src/utils/feed.ts
@@ -1,5 +1,5 @@
 import slugify from '@sindresorhus/slugify'
-import { getCollection } from 'astro:content'
+import { type CollectionEntry, getCollection } from 'astro:content'
 import { Feed } from 'feed'
 import MarkdownIt from 'markdown-it'
 import sanitizeHtml from 'sanitize-html'
@@ -36,7 +36,7 @@ export const getFeed = async () => {
   feed.addCategory(site.data.category)
 
   // add the authors as contributors
-  authors.map(({ id, data: { name, email } }) => {
+  authors.map(({ id, data: { name, email } }: CollectionEntry<'author'>) => {
     return feed.addContributor({
       name: name,
       email: email,
@@ -46,7 +46,9 @@ export const getFeed = async () => {
 
   // add an item for each article
   articles.map((article) => {
-    const author = authors.filter((author) => author.id == article.data.author.id)[0]
+    const author = authors.filter(
+      (author: CollectionEntry<'author'>) => author.id == article.data.author.id
+    )[0]
 
     return feed.addItem({
       title: article.data.title,

--- a/src/utils/tag.ts
+++ b/src/utils/tag.ts
@@ -1,0 +1,69 @@
+import { getArticles } from './article'
+
+/**
+ * @type TagsResponse
+ * The response from a request for a list of tags / categories.
+ */
+export type TagsResponse = Promise<Array<string>>
+
+/**
+ * @type TagsWithCountResponse
+ * The response from a request for tags with the count of usage.
+ */
+export type TagsWithCountResponse = Promise<{ tags: Map<string, number>; total: number }>
+
+/**
+ * Get a list of categories.
+ */
+export const getCategories = async (): TagsResponse => {
+  const articles = await getArticles()
+  const categories = new Set<string>(articles.map((article) => article.data.category))
+  return Array.from(categories)
+}
+
+/**
+ * Get a map of categories with the number of times they have occurred.
+ * Includes the total number of categories.
+ */
+export const getCategoriesWithCount = async (): TagsWithCountResponse => {
+  const articles = await getArticles()
+  const categories = new Map()
+  let total = 0
+  articles.forEach((article) => {
+    const category = article.data.category
+    const value = (categories.get(category) || 0) + 1
+    categories.set(category, value)
+    total += value
+  })
+  return { tags: categories, total }
+}
+
+/**
+ * Get a list of tags.
+ */
+export const getTags = async (): TagsResponse => {
+  const articles = await getArticles()
+  const tags = new Set<string>(
+    articles.flatMap((article) => article.data.tags.map((tag: string) => tag))
+  )
+
+  return Array.from(tags)
+}
+
+/**
+ * Get a map of tags with the number of times they have occurred.
+ * Includes the total number of tags.
+ */
+export const getTagsWithCount = async (): TagsWithCountResponse => {
+  const articles = await getArticles()
+  const tags = new Map()
+  let total = 0
+  articles.forEach((article) => {
+    article.data.tags.forEach((tag: string) => {
+      const value = (tags.get(tag) || 0) + 1
+      tags.set(tag, value)
+      total += value
+    })
+  })
+  return { tags, total }
+}


### PR DESCRIPTION
split the article util so that tag / category related functionality is in it's own file. Add a related article function that compares the category and tags on articles to select the most related ones. Create a component for showing the related and add it to the article page.

fixes #173 

