### PR TITLE
Improve linting stance by adding a11y

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,6 +7,7 @@ import astroLint from 'eslint-plugin-astro'
 import sortLint from 'eslint-plugin-simple-import-sort'
 import vitestLint from 'eslint-plugin-vitest'
 import tsLint from 'typescript-eslint'
+
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
 const gitignorePath = path.resolve(dirname, '.gitignore')
@@ -19,6 +20,7 @@ export default [
   jsLint.configs.recommended,
   ...tsLint.configs.recommended,
   ...astroLint.configs.recommended,
+  ...astroLint.configs['jsx-a11y-recommended'],
   {
     plugins: {
       'simple-import-sort': sortLint,

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@vitest/coverage-v8": "^2.0.3",
     "eslint": "^9.9.0",
     "eslint-plugin-astro": "^1.2.3",
+    "eslint-plugin-jsx-a11y": "^6.10.0",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "eslint-plugin-vitest": "^0.5.4",
     "prettier": "^3.2.5",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agingdeveloper",
   "private": true,
   "description": "The personal site of Richard Klein",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "type": "module",
   "scripts": {
     "dev": "npx astro dev",


### PR DESCRIPTION
## Proposed changes
Now that eslint-jsx-a11y supports eslint 9.0 add that to our configuration. Fixes #693 

## Types of changes

Non-breaking linting change

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Link to issue to close it
