### PR TITLE
Add an alert component that can be used in posts

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agingdeveloper",
   "private": true,
   "description": "The personal site of Richard Klein",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "type": "module",
   "scripts": {
     "dev": "npx astro dev",

--- a/src/components/Alert.astro
+++ b/src/components/Alert.astro
@@ -1,0 +1,48 @@
+---
+/**
+ * @name Alert
+ * Component used for for showing an alert.
+ *
+ * @param {Props} props - The severity and classes.
+ * @return {Function} an Astro component factory function.
+ *
+ * @example
+ * <Alert severity={'info'}>{'This is informational.'}</Alert>
+ *
+ */
+import { Icon } from 'astro-icon/components'
+
+const severityValues = ['success', 'info', 'warning', 'error'] as const
+type SeverityValues = (typeof severityValues)[number]
+
+interface Props {
+  severity: SeverityValues
+  class?: string
+}
+
+const { severity = 'success', class: className } = Astro.props
+
+if (!severityValues.includes(severity)) {
+  throw new Error(
+    `Invalid severity value: "${severity}". Allowed values are: ${severityValues.join(', ')}`
+  )
+}
+
+const styles = {
+  success: 'bg-green-100 text-green-600',
+  info: 'bg-blue-100 text-blue-600',
+  warning: 'bg-orange-100 text-orange-600',
+  error: 'bg-red-100 text-red-600',
+}
+const icons = {
+  success: 'mdi:success-circle-outline',
+  info: 'mdi:information-outline',
+  warning: 'mdi:warning-outline',
+  error: 'mdi:error-outline',
+}
+---
+
+<div class:list={['flex items-center rounded-md p-3', styles[severity], className]} role="alert">
+  <Icon name=`${icons[severity]}` class:list={['mr-3']} />
+  <p class:list={['!m-0 text-base']}><slot /></p>
+</div>

--- a/src/components/DisplayLimitAlert.astro
+++ b/src/components/DisplayLimitAlert.astro
@@ -12,7 +12,7 @@
  *
  * @todo Add search to message once implemented.
  */
-import { Icon } from 'astro-icon/components'
+import Alert from '@components/Alert.astro'
 
 interface Props {
   displayed: number
@@ -26,12 +26,8 @@ const remaining = total - displayed
 
 {
   total > displayed ? (
-    <div
-      class:list={['flex items-center rounded-md bg-blue-100 p-3 text-blue-600', className]}
-      role="alert"
-    >
-      <Icon name="mdi:information-outline" class:list={['mr-3']} />
-      <p>{`Maximum number of articles displayed, ${remaining} remaining.`}</p>
-    </div>
+    <Alert severity="info" class:list={className}>
+      {`Maximum number of articles displayed, ${remaining} remaining.`}
+    </Alert>
   ) : null
 }

--- a/src/pages/article/[slug].astro
+++ b/src/pages/article/[slug].astro
@@ -2,6 +2,7 @@
 /**
  * A single article page.
  */
+import Alert from '@components/Alert.astro'
 import ArticleByLine from '@components/ArticleByLine.astro'
 import ArticleImage from '@components/ArticleImage.astro'
 import ArticlePopular from '@components/ArticlePopular.astro'
@@ -82,7 +83,7 @@ const { Content, remarkPluginFrontmatter: frontmatter } = await article.render()
     <ArticleImage featured={data.featured} class:list={['mt-4']} />
     <section class:list={['mt-4 grid grid-cols-6 gap-x-4']}>
       <div class:list={['prose col-span-6 max-w-none', 'md:prose-lg lg:prose-xl lg:col-span-4']}>
-        <Content components={{ a: LinkMDX }} />
+        <Content components={{ a: LinkMDX, Alert: Alert }} />
       </div>
       <div class:list={['hidden lg:col-span-2 lg:block']}>
         <ArticleTimeToRead

--- a/test/components/Alert.test.ts
+++ b/test/components/Alert.test.ts
@@ -1,0 +1,74 @@
+import Alert from '@components/Alert.astro'
+import { experimental_AstroContainer as AstroContainer } from 'astro/container'
+import { beforeAll, expect, test } from 'vitest'
+
+type RenderOptions = { children?: Record<string, any>; severity?: string; className?: string }
+let alert: string
+
+beforeAll(async () => {
+  alert = await render({ children: { default: 'test message' } })
+})
+
+const render = async ({ children, severity, className }: RenderOptions = {}) => {
+  const container = await AstroContainer.create()
+  return await container.renderToString(Alert, {
+    slots: children,
+    props: {
+      severity: severity,
+      class: className,
+    },
+  })
+}
+test('that it contains alert role', async () => {
+  expect(alert).toContain('role="alert"')
+})
+
+test('that default severity contains the success icon and is green', async () => {
+  expect(alert).toContain('mdi:success-circle-outline')
+  expect(alert).toContain('bg-green-100')
+  expect(alert).toContain('text-green-600')
+})
+
+test('that error severity contains the error icon and is red', async () => {
+  const result = await render({ severity: 'error' })
+  expect(result).toContain('mdi:error-outline')
+  expect(result).toContain('bg-red-100')
+  expect(result).toContain('text-red-600')
+})
+
+test('that warning severity contains the warning icon and is orange', async () => {
+  const result = await render({ severity: 'warning' })
+  expect(result).toContain('mdi:warning-outline')
+  expect(result).toContain('bg-orange-100')
+  expect(result).toContain('text-orange-600')
+})
+
+test('that info severity contains the info icon and is blue', async () => {
+  const result = await render({ severity: 'info' })
+  expect(result).toContain('mdi:information-outline')
+  expect(result).toContain('bg-blue-100')
+  expect(result).toContain('text-blue-600')
+})
+
+test('that success severity contains the success icon and is green', async () => {
+  const result = await render({ severity: 'success' })
+  expect(result).toContain('mdi:success-circle-outline')
+  expect(result).toContain('bg-green-100')
+  expect(result).toContain('text-green-600')
+})
+
+test('that invalid severity throws an error', async () => {
+  await expect(render({ severity: 'invalid' })).rejects.toThrowError(
+    /Invalid severity value: "invalid"/
+  )
+})
+
+test('that it contains the children', async () => {
+  const result = await render({ children: { default: 'new test message' } })
+  expect(result).toContain('new test message')
+})
+
+test('that class is set', async () => {
+  const result = await render({ className: 'test-class' })
+  expect(result).toContain('test-class')
+})


### PR DESCRIPTION
## Proposed changes

In one of the posts I'm working on, I would like to have some alerts in the content. This adds an Alert component that can be used in mdx content.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] Link to issue to close it

## Further comments

Alert component with tests that the DisplayLimitAlert uses and that can be used from within mdx content.
