### PR TITLE
Add a typeahead search to the 404 page to help find what they are lookking for

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -31,24 +31,34 @@ export default defineConfig({
   image: {},
   integrations: [
     icon(),
-    fuse(['content', 'frontmatter.title', 'frontmatter.description', 'frontmatter.keywords'], {
-      filter: (path) => /^\/article\/(?!archive).*/.test(path),
-      extractContentFromHTML: ($) => $('.prose'),
-      extractFrontmatterFromHTML: ($) => {
-        const frontmatter: Record<string, any> = {}
-        const ld = $('script[type="application/ld+json"]').html() ?? '{}'
-        const ldJson = JSON.parse(ld)
+    fuse(
+      [
+        'content',
+        'frontmatter.title',
+        'frontmatter.description',
+        'frontmatter.category',
+        'frontmatter.tags',
+      ],
+      {
+        filter: (path) => /^\/article\/(?!archive).*/.test(path),
+        extractContentFromHTML: ($) => $('.prose'),
+        extractFrontmatterFromHTML: ($) => {
+          const frontmatter: Record<string, any> = {}
+          const ld = $('script[type="application/ld+json"]').html() ?? '{}'
+          const ldJson = JSON.parse(ld)
 
-        // TODO update this when BlogPosting moves to the mainEntity
-        if (ldJson['@type'] === 'BlogPosting') {
-          frontmatter.title = ldJson.headline
-          frontmatter.description = ldJson.description
-          frontmatter.keywords = ldJson.keywords
-        }
+          // TODO update this when BlogPosting moves to the mainEntity
+          if (ldJson['@type'] === 'BlogPosting') {
+            frontmatter.title = ldJson.headline
+            frontmatter.description = ldJson.description
+            frontmatter.category = ldJson.articleSection
+            frontmatter.tags = ldJson.keywords
+          }
 
-        return frontmatter
-      },
-    }),
+          return frontmatter
+        },
+      }
+    ),
     mdx(),
     sitemap(),
     tailwind({

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agingdeveloper",
   "private": true,
   "description": "The personal site of Richard Klein",
-  "version": "4.1.2",
+  "version": "4.2.0",
   "type": "module",
   "scripts": {
     "clean": "rm -rf .astro dist node_modules package-lock.json",
@@ -34,8 +34,10 @@
     "@sindresorhus/slugify": "^2.2.1",
     "@tailwindcss/typography": "^0.5.13",
     "astro": "^5.0.4",
+    "astro-fuse": "^1.0.1",
     "astro-icon": "^1.1.1",
     "feed": "^4.2.2",
+    "fuse.js": "^7.0.0",
     "install": "^0.13.0",
     "license-report": "^6.7.1",
     "markdown-it": "^14.1.0",
@@ -68,6 +70,9 @@
     "vite": "^6.0.1",
     "@typescript-eslint/utils": {
       "eslint": "^9.9.0"
+    },
+    "astro-fuse": {
+      "astro": "^5.0.4"
     }
   }
 }

--- a/src/components/TypeaheadSearch.astro
+++ b/src/components/TypeaheadSearch.astro
@@ -1,0 +1,122 @@
+---
+import { Icon } from 'astro-icon/components'
+
+interface Props {
+  class?: string
+}
+
+const { class: className } = Astro.props
+---
+
+<typeahead-search>
+  <div data-search-container class:list={['relative', className]}>
+    <input
+      type="text"
+      data-search-input
+      placeholder={'Search...'}
+      class:list={[
+        'w-full rounded-md border border-gray-300 px-3 py-2 pl-10',
+        'focus:outline-none focus:ring-2 focus:ring-blue-500',
+      ]}
+    />
+    <div class="absolute inset-y-0 left-0 flex items-center">
+      <Icon class:list={['pointer-events-none text-stone-400', 'ml-3 h-6 w-6']} name="mdi:search" />
+    </div>
+    <ul
+      data-search-result
+      class:list={[
+        'absolute z-10 hidden max-h-48 w-full overflow-y-auto rounded-md border border-stone-300 bg-white shadow-lg',
+      ]}
+    >
+    </ul>
+  </div>
+</typeahead-search>
+
+<script>
+  import type { OutputBaseSearchable } from 'astro-fuse'
+
+  class TypeaheadSearch extends HTMLElement {
+    list: HTMLUListElement | null = null
+    input: HTMLInputElement | null = null
+    blurTimeout: number | null = null
+
+    constructor() {
+      super()
+
+      this.list = this.querySelector<HTMLUListElement>('[data-search-result]')
+      this.input = this.querySelector<HTMLInputElement>('[data-search-input]')
+
+      if (this.input) {
+        this.input.addEventListener('input', this.onInput.bind(this))
+        this.input.addEventListener('focus', this.onFocus.bind(this))
+        this.input.addEventListener('blur', this.onBlur.bind(this))
+      }
+
+      if (this.list) {
+        this.list.addEventListener('mousedown', (e) => e.preventDefault())
+        this.list.addEventListener('focus', this.onListFocus.bind(this))
+        this.list.addEventListener('blur', this.onListBlur.bind(this))
+      }
+    }
+
+    async onInput(e: Event) {
+      const { list } = this
+      if (!list) {
+        return
+      }
+
+      const { loadFuse } = await import('astro-fuse/client')
+      const fuse = await loadFuse()
+      const query = (e.target as HTMLInputElement).value.trim()
+
+      const results = fuse.search<OutputBaseSearchable>(query)
+
+      if (results.length <= 0) {
+        list.innerHTML = ''
+        list.classList.add('hidden')
+      } else {
+        list.innerHTML = results
+          .map(
+            ({ item }) =>
+              `<li><a class="block w-full px-4 py-1 hover:bg-stone-100 focus:bg-stone-100 focus:outline-none" data-link="internal" data-astro-prefetch="hover" target="_self" href="${item.pathname}">${item.frontmatter.title}</a></li>`
+          )
+          .join('')
+        list.classList.remove('hidden')
+      }
+    }
+
+    onFocus(e: FocusEvent) {
+      this.cancelTimeout()
+      this.onInput(e)
+    }
+
+    onBlur() {
+      const { list } = this
+      this.blurTimeout = window.setTimeout(() => {
+        if (list) {
+          list.classList.add('hidden')
+        }
+      }, 100)
+    }
+
+    onListFocus() {
+      this.cancelTimeout()
+    }
+
+    onListBlur(e: FocusEvent) {
+      if (this.list?.contains(e.relatedTarget as Node)) {
+        return // Prevent hiding if the focus moves to an anchor inside the list
+      }
+      this.onBlur()
+    }
+
+    cancelTimeout() {
+      if (this.blurTimeout) {
+        clearTimeout(this.blurTimeout)
+        this.blurTimeout = null
+      }
+    }
+  }
+
+  customElements.define('typeahead-search', TypeaheadSearch)
+</script>

--- a/src/components/seo/ArticleJson.astro
+++ b/src/components/seo/ArticleJson.astro
@@ -37,11 +37,13 @@ const modifiedDate = article.data.modified ? article.data.modified : article.dat
     author: [
       {
         '@type': 'Person',
+        identifier: author.id,
         name: author.data.name,
         url: buildUrl(`/author/${author.id}`, site.data.origin),
       },
     ],
     wordCount: wordCount,
-    keywords: [article.data.category, author.id, ...article.data.tags],
+    articleSection: article.data.category,
+    keywords: article.data.tags,
   })}
 />

--- a/src/components/seo/ArticleJson.astro
+++ b/src/components/seo/ArticleJson.astro
@@ -42,5 +42,6 @@ const modifiedDate = article.data.modified ? article.data.modified : article.dat
       },
     ],
     wordCount: wordCount,
+    keywords: [article.data.category, author.id, ...article.data.tags],
   })}
 />

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -3,6 +3,7 @@ import ArticleImage from '@components/ArticleImage.astro'
 import BackLink from '@components/BackLink.astro'
 import LinkInternal from '@components/LinkInternal.astro'
 import SeoBasic from '@components/seo/SeoBasic.astro'
+import TypeaheadSearch from '@components/TypeaheadSearch.astro'
 import Layout from '@layouts/Layout.astro'
 import { getDefaultSite } from '@utils/site'
 
@@ -51,7 +52,7 @@ const featured = {
     <li>
       Go back to our <LinkInternal class:list={['underline']} to={'/'}>Homepage</LinkInternal>.
     </li>
-    <!--<li>Use the search bar below to find what you need.</li> -->
+    <li>Use the search bar below to find what you need.</li>
     <li>
       Explore our popular sections like
       <LinkInternal to={'/author'} class:list={['underline']}>Authors</LinkInternal>{', '}
@@ -59,8 +60,12 @@ const featured = {
       <LinkInternal to={'/tag'} class:list={['underline']}>Tags</LinkInternal>{'.'}
     </li>
   </ul>
+
+  <TypeaheadSearch class:list={['mt-4']} />
+
   <p class:list={['mt-4']}>
     {"We're sorry for the inconvenience!"}
   </p>
+
   <BackLink name={'Home'} to={'/'} useViewText={false} class:list={['mt-8']} />
 </Layout>

--- a/src/utils/article.ts
+++ b/src/utils/article.ts
@@ -1,4 +1,4 @@
-import { type CollectionEntry, getCollection } from 'astro:content'
+import { type CollectionEntry, getCollection, getEntry } from 'astro:content'
 
 import { intersection } from './misc'
 
@@ -34,6 +34,20 @@ export const getArticles = async (limit?: number, exclude?: string): ArticlesRes
         b.data.published.valueOf() - a.data.published.valueOf()
     )
     .slice(0, limit)
+}
+
+/**
+ * @name getArticleById
+ *
+ * Get a single article entry based on the id.
+ *
+ * @param id - The ide of the article to return.
+ * @returns The article to return
+ */
+export const getArticleById = async (
+  id: string
+): Promise<CollectionEntry<'article'> | undefined> => {
+  return getEntry('article', id)
 }
 
 /**

--- a/test/components/TypeaheadSearch.test.ts
+++ b/test/components/TypeaheadSearch.test.ts
@@ -1,0 +1,5 @@
+import { describe, test } from 'vitest'
+
+describe('typeaheadSearch', () => {
+  test.todo('implement tests for this component')
+})

--- a/test/components/seo/ArticleJson.test.ts
+++ b/test/components/seo/ArticleJson.test.ts
@@ -1,0 +1,116 @@
+import ArticleJson from '@components/seo/ArticleJson.astro'
+import { getArticleById } from '@utils/article'
+import { getDefaultAuthor } from '@utils/author'
+import { buildUrl } from '@utils/misc'
+import { getDefaultSite } from '@utils/site'
+import { experimental_AstroContainer as AstroContainer } from 'astro/container'
+import type { CollectionEntry } from 'astro:content'
+import { beforeAll, describe, expect, test } from 'vitest'
+
+describe('articleJson', () => {
+  let article: CollectionEntry<'article'> | undefined
+  let author: CollectionEntry<'author'>
+  let site: CollectionEntry<'site'>
+
+  let linkedData: string
+
+  beforeAll(async () => {
+    site = await getDefaultSite()
+    article = await getArticleById('mock-article-1')
+    author = await getDefaultAuthor()
+
+    linkedData = await render(site, author, article)
+  })
+
+  const render = async (
+    site: CollectionEntry<'site'>,
+    author: CollectionEntry<'author'>,
+    article?: CollectionEntry<'article'>
+  ) => {
+    if (!article) {
+      linkedData = ''
+    }
+
+    const container = await AstroContainer.create()
+    return await container.renderToString(ArticleJson, {
+      props: {
+        site: site,
+        article: article,
+        author: author,
+        wordCount: 100,
+      },
+    })
+  }
+
+  test('that it contains an ld+json', async () => {
+    expect(linkedData).toContain('<script type="application/ld+json">')
+  })
+
+  test('that it contains a blog posting', async () => {
+    expect(linkedData).toContain('"@type":"BlogPosting"')
+  })
+
+  test('that it contains the title', async () => {
+    expect(linkedData).toContain(`"headline":"${article?.data.title}"`)
+  })
+
+  test('that it contains the description', async () => {
+    expect(linkedData).toContain(`"description":"${article?.data.description}"`)
+  })
+
+  test('that it contains an image url', async () => {
+    if (!article) {
+      throw new Error('Article is not defined')
+    }
+
+    const imageUrl = buildUrl(article?.data.featured.image.src, site.data.origin)
+    expect(linkedData).toContain(`"image":["${imageUrl.toString()}"]`)
+  })
+
+  test('that it contains the date published', async () => {
+    expect(linkedData).toContain(`"datePublished":"${article?.data.published.toISOString()}"`)
+  })
+
+  test('that it contains the date modified', async () => {
+    expect(linkedData).toContain(`"dateModified":"${article?.data.published.toISOString()}"`)
+  })
+
+  test('that it contains the date modified when different from published', async () => {
+    const modifiedArticle = await getArticleById('mock-article-with-modified')
+    const linkedData = await render(site, author, modifiedArticle)
+
+    expect(linkedData).toContain(
+      `"dateModified":"${modifiedArticle?.data.modified?.toISOString()}"`
+    )
+  })
+
+  test('that it contains an author', async () => {
+    expect(linkedData).toContain('"author":[')
+    expect(linkedData).toContain('"@type":"Person"')
+  })
+
+  test('that it contains the author id', async () => {
+    expect(linkedData).toContain(`"identifier":"${author.id}"`)
+  })
+
+  test('that it contains the author name', async () => {
+    expect(linkedData).toContain(`"name":"${author.data.name}"`)
+  })
+
+  test('that it contains the author url', async () => {
+    expect(linkedData).toContain(`"url":"${buildUrl(`/author/${author.id}`, site.data.origin)}"`)
+  })
+
+  test('that it contains the word count', async () => {
+    expect(linkedData).toContain(`"wordCount":100`)
+  })
+
+  test('that it contains the section', async () => {
+    expect(linkedData).toContain(`"articleSection":"${article?.data.category}"`)
+  })
+
+  test('that it contains the tags', async () => {
+    const tags = `["${article?.data.tags.join('","')}"]`
+    expect(linkedData).toContain(`"keywords":${tags}`)
+  })
+})

--- a/test/components/seo/BreadcrumbJson.test.ts
+++ b/test/components/seo/BreadcrumbJson.test.ts
@@ -6,11 +6,11 @@ import { beforeAll, describe, expect, test } from 'vitest'
 
 describe('breadcrumbJson', () => {
   let site: CollectionEntry<'site'>
-  let breadcrumb: string
+  let linkedData: string
 
   beforeAll(async () => {
     site = await getDefaultSite()
-    breadcrumb = await render()
+    linkedData = await render()
   })
 
   const render = async () => {
@@ -27,27 +27,27 @@ describe('breadcrumbJson', () => {
   }
 
   test('that it contains an ld+json', async () => {
-    expect(breadcrumb).toContain('<script type="application/ld+json">')
+    expect(linkedData).toContain('<script type="application/ld+json">')
   })
 
   test('that it contains an breadcrumb list', async () => {
-    expect(breadcrumb).toContain('"@type":"BreadcrumbList"')
+    expect(linkedData).toContain('"@type":"BreadcrumbList"')
   })
 
   test('that it contains site as the base item', async () => {
-    expect(breadcrumb).toContain(
+    expect(linkedData).toContain(
       '"position":1,"name":"The Aging Developer","item":"http://localhost:4321'
     )
   })
 
   test('that it contains the article index crumb', async () => {
-    expect(breadcrumb).toContain(
+    expect(linkedData).toContain(
       '"position":2,"name":"Articles","item":"http://localhost:4321/article"'
     )
   })
 
   test('that it contains the article crumb', async () => {
-    expect(breadcrumb).toContain(
+    expect(linkedData).toContain(
       '"position":3,"name":"Title","item":"http://localhost:4321/article/slug"'
     )
   })

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -21,6 +21,48 @@ vi.mock('astro:content', () => {
           collection: 'author',
           data: authorData.find((entry) => entry.id == DEFAULT_AUTHOR_ID),
         }
+      } else if (collection == 'article') {
+        switch (id) {
+          case 'mock-article-1':
+            return {
+              id: `${id}`,
+              collection: 'article',
+              data: {
+                title: 'Mock Article 1',
+                description: 'Mock article 1 description',
+                featured: {
+                  image: {
+                    src: 'mock-article-image.jpg',
+                  },
+                },
+                published: new Date(),
+                category: 'mock-category',
+                tags: ['mock-tag'],
+              },
+            }
+
+          case 'mock-article-with-modified':
+            return {
+              id: `${id}`,
+              collection: 'article',
+              data: {
+                title: 'Mock Article with Modified',
+                description: 'Mock article with modified description',
+                featured: {
+                  image: {
+                    src: 'mock-article-image.jpg',
+                  },
+                },
+                published: new Date(),
+                modified: new Date(),
+                category: 'mock-category',
+                tags: ['mock-tag'],
+              },
+            }
+
+          default:
+            return null // Simulate no entry found
+        }
       }
       return null // Simulate no entry found
     }),


### PR DESCRIPTION
## Proposed changes
To make it easier to figure out where you've gone wrong when hitting the 404 page provide a search that can be used to find what they are looking for. This isn't the original idea for #174, but it does fix it.

fixes #174

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Link to issue to close it

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
