### PR TITLE
Fix validation errors in the RSS and Atom Feeds

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agingdeveloper",
   "private": true,
   "description": "The personal site of Richard Klein",
-  "version": "5.1.5",
+  "version": "5.2.0",
   "type": "module",
   "scripts": {
     "clean": "rm -rf .astro dist node_modules package-lock.json",

--- a/src/utils/feed.ts
+++ b/src/utils/feed.ts
@@ -1,3 +1,4 @@
+import { getImage } from 'astro:assets'
 import { type CollectionEntry, getCollection } from 'astro:content'
 import { Feed } from 'feed'
 import MarkdownIt from 'markdown-it'
@@ -52,6 +53,9 @@ export const getFeed = async (): Promise<Feed> => {
     })
   })
 
+  // map of image urls that can be replaced in the content
+  const imageUrls = await buildImageUrls()
+
   // add an item for each article
   articles.map((article) => {
     const author = authors.filter(
@@ -59,6 +63,17 @@ export const getFeed = async (): Promise<Feed> => {
     )[0]
 
     const articleUrl = buildUrl(`/article/${article.id}`, site.data.origin).href
+
+    // convert the image path to something that can be looked up in the imageUrls map
+    const imagePath = article.data.featured.image.src
+      .split('/article/')[1]
+      .split('?')[0]
+      .replace(/^(\d{4})\/([^/]+)/, (_, year, rest) => {
+        return `${year}-${rest}`
+      })
+    const imageSrc = imageUrls.get(imagePath) || article.data.featured.image.src
+    console.log('imageSrc', imageSrc)
+
     return feed.addItem({
       title: article.data.title,
       id: articleUrl,
@@ -74,19 +89,25 @@ export const getFeed = async (): Promise<Feed> => {
         },
       ],
       image: {
-        url: escapeXmlAttr(buildUrl(article.data.featured.image.src, site.data.origin).href),
-        type: mime.getType(article.data.featured.image.src.split('?')[0]) || undefined,
+        url: escapeXmlAttr(buildUrl(imageSrc, site.data.origin).href),
+        type: mime.getType(imageSrc.split('?')[0]) || undefined,
       },
       content: sanitizeHtml(parser.render(article.body || ''), {
         allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
         transformTags: {
           img: (tagName, attribs) => {
             const { src } = attribs
+            let imageSrc = src
+            if (!src.startsWith('./')) {
+              const imagePath = `${article.id}/${src.replace(/^\.\//, '')}`
+              imageSrc = imageUrls.get(imagePath) || src
+            }
+
             return {
               tagName,
               attribs: {
                 ...attribs,
-                src: buildUrl(src, articleUrl).href,
+                src: buildUrl(imageSrc, site.data.origin).href,
               },
             }
           },
@@ -106,6 +127,36 @@ export const getFeed = async (): Promise<Feed> => {
   })
 
   return feed
+}
+
+/**
+ * Build a map of Image Urls
+ *
+ * This function will build a map of image urls for all images in the content directory.
+ * The keys will be the relative file path to the image starting after the article folder,
+ * and the values will be the relative url to the image.
+ *
+ * @returns a Map of image urls
+ */
+const buildImageUrls = async (): Promise<Map<string, string>> => {
+  const imageGlobs = import.meta.glob<{ default: ImageMetadata }>(
+    `/src/content/article/**/*.{jpeg,jpg,png,gif,svg,webp}`
+  )
+
+  const images: Map<string, string> = new Map()
+  for (const key of Object.keys(imageGlobs)) {
+    const src = key
+      .split('?')[0]
+      .replace(/^\/?src\/content\/article\//, '')
+      .replace(/^(\d{4})\/([^/]+)/, (_, year, rest) => {
+        return `${year}-${rest}`
+      })
+    const metadata = await imageGlobs[key]().then((result) => result.default)
+    const image = await getImage({ src: metadata })
+    console.log('image', image)
+    images.set(src, image.src)
+  }
+  return images
 }
 
 /**

--- a/src/utils/feed.ts
+++ b/src/utils/feed.ts
@@ -79,6 +79,31 @@ export const getFeed = async (): Promise<Feed> => {
       },
       content: sanitizeHtml(parser.render(article.body || ''), {
         allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
+        transformTags: {
+          img: (tagName, attribs) => {
+            const { src, alt } = attribs
+            return {
+              tagName: 'img',
+              attribs: {
+                src: buildUrl(src, site.data.origin).href,
+                alt: alt,
+                class: 'w-full h-auto',
+              },
+            }
+          },
+          a: (tagName, attribs) => {
+            const { href, title } = attribs
+            return {
+              tagName: 'a',
+              attribs: {
+                href: buildUrl(href, site.data.origin).href,
+                title: title,
+                target: '_blank',
+                rel: 'noopener noreferrer',
+              },
+            }
+          },
+        },
       }),
     })
   })

--- a/src/utils/feed.ts
+++ b/src/utils/feed.ts
@@ -81,25 +81,22 @@ export const getFeed = async (): Promise<Feed> => {
         allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
         transformTags: {
           img: (tagName, attribs) => {
-            const { src, alt } = attribs
+            const { src } = attribs
             return {
-              tagName: 'img',
+              tagName,
               attribs: {
-                src: buildUrl(src, site.data.origin).href,
-                alt: alt,
-                class: 'w-full h-auto',
+                ...attribs,
+                src: buildUrl(src, articleUrl).href,
               },
             }
           },
           a: (tagName, attribs) => {
-            const { href, title } = attribs
+            const { href } = attribs
             return {
-              tagName: 'a',
+              tagName,
               attribs: {
-                href: buildUrl(href, site.data.origin).href,
-                title: title,
-                target: '_blank',
-                rel: 'noopener noreferrer',
+                ...attribs,
+                href: buildUrl(href, articleUrl).href,
               },
             }
           },

--- a/src/utils/feed.ts
+++ b/src/utils/feed.ts
@@ -169,13 +169,13 @@ class FeedImageCollection {
 
     // first load the images from the site entry
     let image = await getImage({ src: this.site.data.avatar })
-    this.images.set(this.trimKey(this.site.data.avatar.src), image)
+    this.images.set(this.normalizeKey(this.site.data.avatar.src), image)
     image = await getImage({ src: this.site.data.icon })
-    this.images.set(this.trimKey(this.site.data.icon.src), image)
+    this.images.set(this.normalizeKey(this.site.data.icon.src), image)
 
     // load all the images that are in the article directory
     for (const key of Object.keys(imageGlobs)) {
-      const src = this.trimKey(key)
+      const src = this.normalizeKey(key)
       const metadata = await imageGlobs[key]().then((result) => result.default)
       image = await getImage({ src: metadata })
       this.images.set(src, image)
@@ -198,7 +198,7 @@ class FeedImageCollection {
       return src
     }
 
-    let key = this.trimKey(src).replace(/^.\//, '')
+    let key = this.normalizeKey(src).replace(/^.\//, '')
     key = key.startsWith(articlePath) ? key : `${articlePath}/${key}`
     const image = this.images.get(key)
     if (image) {
@@ -219,7 +219,7 @@ class FeedImageCollection {
    * @returns The image url or empty if not found.
    */
   getImageSrc(src: string): string {
-    const key = this.trimKey(src)
+    const key = this.normalizeKey(src)
     const image = this.images.get(key)
     if (image) {
       return buildUrl(image.src, this.site.data.origin).href
@@ -236,7 +236,7 @@ class FeedImageCollection {
    * @param key the key to normalize
    * @returns The normalized key
    */
-  private trimKey(key: string): string {
+  private normalizeKey(key: string): string {
     return key
       .split('?')[0]
       .replace('/@fs', '')

--- a/src/utils/feed.ts
+++ b/src/utils/feed.ts
@@ -196,7 +196,7 @@ class FeedImageCollection {
    * @returns The image url or empty if not found.
    */
   getArticleImageSrc(src: string, articlePath: string): string {
-    if (src.startsWith('http') || src.startsWith('https')) {
+    if (src.startsWith('http') || src.startsWith('data')) {
       return src
     }
 

--- a/src/utils/feed.ts
+++ b/src/utils/feed.ts
@@ -72,7 +72,6 @@ export const getFeed = async (): Promise<Feed> => {
         return `${year}-${rest}`
       })
     const imageSrc = imageUrls.get(imagePath) || article.data.featured.image.src
-    console.log('imageSrc', imageSrc)
 
     return feed.addItem({
       title: article.data.title,
@@ -90,7 +89,7 @@ export const getFeed = async (): Promise<Feed> => {
       ],
       image: {
         url: escapeXmlAttr(buildUrl(imageSrc, site.data.origin).href),
-        type: mime.getType(imageSrc.split('?')[0]) || undefined,
+        type: mime.getType(imageSrc) || undefined,
       },
       content: sanitizeHtml(parser.render(article.body || ''), {
         allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -39,11 +39,17 @@ export const intersection = (first: Array<string>, second: Array<string>): Set<s
 /**
  * Build an absolute url for the given path and origin.
  *
+ * If the path is already an absolute url, it will be returned as is. Otherwise,
+ * the path will be combined with the origin to create a new url.
+ *
  * @param path - the path to construct the url for.
  * @param base - the origin.
  * @returns the full url.
  */
 export const buildUrl = (path: string, origin: URL | string): URL => {
+  if (path.startsWith('http')) {
+    return new URL(path)
+  }
   return new URL(path, origin)
 }
 

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -47,9 +47,6 @@ export const intersection = (first: Array<string>, second: Array<string>): Set<s
  * @returns the full url.
  */
 export const buildUrl = (path: string, origin: URL | string): URL => {
-  if (path.startsWith('http')) {
-    return new URL(path)
-  }
   return new URL(path, origin)
 }
 

--- a/test/utils/misc.test.ts
+++ b/test/utils/misc.test.ts
@@ -90,6 +90,11 @@ describe('buildUrl', () => {
   test('that it can handle an empty path', () => {
     expect(buildUrl('', origin).href).toEqual(origin + '/')
   })
+
+  test('that it can handle a full url', () => {
+    const fullUrl: string = 'http://example.com/article/2024-11-11-article'
+    expect(buildUrl(fullUrl, origin).href).toEqual(fullUrl)
+  })
 })
 
 describe('formatDate', () => {


### PR DESCRIPTION
## Proposed changes

The encoded html in the content of atom and RSS feeds can not have relative urls in them. Use the transformTag method of the sanitize-html plugin to switch anchor tag href and image src properties to be absolute. Load all the images up ahead of time and store them in a map with a normalized key so that we can later look them up and get the absolute url for them. Fixes #760 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Link to issue to close it