### PR TITLE
[codex] move Astro fonts into the asset pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,12 @@
 # Repository Instructions
 
+## Toolchain
+
+This repository uses:
+
+- Node.js for runtime and scripts
+- `pnpm` as the package manager and script runner
+
 Use the local skill at `.agents/skills/code-linter-fixer` whenever a task changes any `.js`, `.mjs`, `.cjs`, `.ts`, `.astro`, `.md`, or `.mdx` file in this repository.
 
 After those edits, run these scripts before finishing:
@@ -14,3 +21,9 @@ For larger changes, dependency changes, CI changes, or changes that may affect b
 ```bash
 pnpm run verify
 ```
+
+## Release Versioning
+
+`package.json` is the release version source of truth.
+A new release is indicated by bumping the `version` field in `package.json`.
+Do not change the version unless the work is intended to produce a release.

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -2,7 +2,7 @@ import mdx from '@astrojs/mdx'
 import netlify from '@astrojs/netlify'
 import sitemap from '@astrojs/sitemap'
 import tailwindcss from '@tailwindcss/vite'
-import { defineConfig, envField } from 'astro/config'
+import { defineConfig, envField, fontProviders } from 'astro/config'
 import icon from 'astro-icon'
 
 import { remarkExcerpt } from './src/utils/excerpt.ts'
@@ -18,6 +18,32 @@ const siteUrl =
 export default defineConfig({
   adapter: netlify(),
   build: { format: 'file' },
+  fonts: [
+    {
+      provider: fontProviders.npm({ remote: false }),
+      name: 'Noto Sans Georgian',
+      cssVariable: '--font-noto-sans-georgian',
+      options: { package: '@fontsource/noto-sans-georgian' },
+    },
+    {
+      provider: fontProviders.npm({ remote: false }),
+      name: 'Noto Serif Georgian',
+      cssVariable: '--font-noto-serif-georgian',
+      options: { package: '@fontsource/noto-serif-georgian' },
+    },
+    {
+      provider: fontProviders.npm({ remote: false }),
+      name: 'Fira Code',
+      cssVariable: '--font-fira-code',
+      options: { package: '@fontsource/fira-code' },
+    },
+    {
+      provider: fontProviders.npm({ remote: false }),
+      name: 'Walter Turncoat',
+      cssVariable: '--font-walter-turncoat',
+      options: { package: '@fontsource/walter-turncoat' },
+    },
+  ],
   env: {
     schema: {
       DEPLOY_CONTEXT: envField.string({

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agingdeveloper",
   "private": true,
   "description": "The personal site of Richard Klein",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "type": "module",
   "packageManager": "pnpm@10.24.0",
   "scripts": {

--- a/src/components/PageHeader.astro
+++ b/src/components/PageHeader.astro
@@ -43,7 +43,7 @@ const { site, class: className } = Astro.props
             >
               <Image
                 src={site.data.avatar}
-                alt={site.data.title}
+                alt=""
                 loading={'eager'}
                 fetchpriority={'high'}
                 width={80}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,15 +1,12 @@
 ---
 import '@styles/main.css'
-import '@fontsource/noto-serif-georgian'
-import '@fontsource/noto-sans-georgian'
-import '@fontsource/fira-code'
-import '@fontsource/walter-turncoat'
 
 import PageFooter from '@components/PageFooter.astro'
 import PageHeader from '@components/PageHeader.astro'
 import ScrollTop from '@components/ScrollTop.astro'
 import { feedInfo } from '@utils/feed'
 import { buildUrl } from '@utils/misc'
+import { Font } from 'astro:assets'
 import type { CollectionEntry } from 'astro:content'
 import { ANALYTICS_TRACKING_ID } from 'astro:env/client'
 import { DEPLOY_CONTEXT } from 'astro:env/server'
@@ -28,6 +25,10 @@ const analyticsId = DEPLOY_CONTEXT === 'production' ? ANALYTICS_TRACKING_ID : ''
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
+    <Font cssVariable="--font-noto-sans-georgian" preload />
+    <Font cssVariable="--font-noto-serif-georgian" />
+    <Font cssVariable="--font-fira-code" />
+    <Font cssVariable="--font-walter-turncoat" />
     <meta name="theme-color" content={data.theme} />
     <link rel="icon" type="image/x-icon" href="/icons/favicon.ico" />
     <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png" />

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -13,20 +13,23 @@
   --color-secondary-dark: rgb(90, 146, 22);
   --color-secondary-contrast: rgb(46, 46, 46);
 
-  --font-mono:
-    Fira Code, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
-    'Courier New', monospace;
-  --font-serif: Noto Serif Georgian, ui-serif, Georgia, Cambria, 'Times New Roman', Times, serif;
-  --font-sans:
-    Noto Sans Georgian, ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
-    'Segoe UI Symbol', 'Noto Color Emoji';
-  --font-chalk:
-    Walter Turncoat, ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
-    'Segoe UI Symbol', 'Noto Color Emoji';
-
   --breakpoint-xs: 420px;
 
   --aspect-ultrawide: 21 / 9;
+}
+
+@theme inline {
+  --font-mono:
+    var(--font-fira-code), ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    'Liberation Mono', 'Courier New', monospace;
+  --font-serif:
+    var(--font-noto-serif-georgian), ui-serif, Georgia, Cambria, 'Times New Roman', Times, serif;
+  --font-sans:
+    var(--font-noto-sans-georgian), ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji',
+    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  --font-chalk:
+    var(--font-walter-turncoat), ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji',
+    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
 }
 
 /*

--- a/test/components/Alert.test.ts
+++ b/test/components/Alert.test.ts
@@ -60,7 +60,7 @@ describe('alert', () => {
   })
 
   test('that invalid severity throws an error', async () => {
-    await expect(render({ severity: 'invalid' })).rejects.toThrowError(
+    await expect(render({ severity: 'invalid' })).rejects.toThrow(
       /Invalid severity value: "invalid"/
     )
   })

--- a/test/utils/misc.test.ts
+++ b/test/utils/misc.test.ts
@@ -19,19 +19,19 @@ describe('calculateWeight', () => {
   })
 
   test('that a zero value throws', () => {
-    expect(() => calculateWeight(0, 5)).toThrowError(/Invalid value/)
+    expect(() => calculateWeight(0, 5)).toThrow(/Invalid value/)
   })
 
   test('that a negative value throws', () => {
-    expect(() => calculateWeight(-1, 5)).toThrowError(/Invalid value/)
+    expect(() => calculateWeight(-1, 5)).toThrow(/Invalid value/)
   })
 
   test('that a zero total throws', () => {
-    expect(() => calculateWeight(5, 0)).toThrowError(/Invalid total/)
+    expect(() => calculateWeight(5, 0)).toThrow(/Invalid total/)
   })
 
   test('that a negative total throws', () => {
-    expect(() => calculateWeight(1, -1)).toThrowError(/Invalid total/)
+    expect(() => calculateWeight(1, -1)).toThrow(/Invalid total/)
   })
 })
 
@@ -76,7 +76,7 @@ describe('buildUrl', () => {
   const full: string = origin + path
 
   test('that it throws on an empty origin', () => {
-    expect(() => buildUrl(path, '')).toThrowError(/Invalid URL/)
+    expect(() => buildUrl(path, '')).toThrow(/Invalid URL/)
   })
 
   test('that it can handle a string origin', () => {


### PR DESCRIPTION
## Summary

This PR publishes three related changes:

- clarifies the repository toolchain and release-versioning instructions in `AGENTS.md`
- moves site fonts into Astro's font asset pipeline, preloads the primary font, marks the header avatar as decorative, and updates Vitest matcher usage in related tests
- bumps the package version from `6.2.0` to `6.2.1`

## Validation

- `pnpm run verify`
