### PR TITLE
feat(images): add responsive image placeholder pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # build output
 dist/
+.cache 
 
 # generated types
 .astro/

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agingdeveloper",
   "private": true,
   "description": "The personal site of Richard Klein",
-  "version": "6.2.1",
+  "version": "6.3.1",
   "type": "module",
   "packageManager": "pnpm@10.24.0",
   "scripts": {
@@ -67,6 +67,7 @@
     "prettier": "^3.2.5",
     "prettier-plugin-astro": "^0.14.1",
     "prettier-plugin-tailwindcss": "^0.7.2",
+    "sharp": "^0.34.5",
     "skills": "^1.4.8",
     "typescript": "^5.4.5",
     "typescript-eslint": "^8.58.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
       prettier-plugin-tailwindcss:
         specifier: ^0.7.2
         version: 0.7.2(prettier-plugin-astro@0.14.1)(prettier@3.8.1)
+      sharp:
+        specifier: ^0.34.5
+        version: 0.34.5
       skills:
         specifier: ^1.4.8
         version: 1.4.8
@@ -14495,7 +14498,7 @@ snapshots:
   normalize-package-data@6.0.2:
     dependencies:
       hosted-git-info: 7.0.2
-      semver: 7.7.2
+      semver: 7.7.4
       validate-npm-package-license: 3.0.4
 
   normalize-package-data@7.0.1:

--- a/src/components/ArticleCard.astro
+++ b/src/components/ArticleCard.astro
@@ -10,8 +10,8 @@
  * <ArticleCard article={entry} />
  */
 import LinkInternal from '@components/LinkInternal.astro'
+import ResponsiveImage from '@components/ResponsiveImage.astro'
 import { formatDate } from '@utils/misc'
-import { Image } from 'astro:assets'
 import type { CollectionEntry } from 'astro:content'
 import { render } from 'astro:content'
 
@@ -36,8 +36,8 @@ const loading = lazy ? 'lazy' : 'eager'
       className,
     ]}
   >
-    <Image
-      src={article.data.featured.image}
+    <ResponsiveImage
+      image={article.data.featured.image}
       alt={article.data.title}
       width={768}
       widths={[180, 420, 500, 640, 768]}

--- a/src/components/ArticleCardLead.astro
+++ b/src/components/ArticleCardLead.astro
@@ -10,8 +10,8 @@
  * <ArticleCardLead article={entry} />
  */
 import LinkInternal from '@components/LinkInternal.astro'
+import ResponsiveImage from '@components/ResponsiveImage.astro'
 import { formatDate } from '@utils/misc'
-import { Image } from 'astro:assets'
 import type { CollectionEntry } from 'astro:content'
 import { render } from 'astro:content'
 
@@ -33,8 +33,8 @@ const { remarkPluginFrontmatter: frontmatter } = await render(article)
       className,
     ]}
   >
-    <Image
-      src={article.data.featured.image}
+    <ResponsiveImage
+      image={article.data.featured.image}
       alt={article.data.title}
       class:list={['aspect-ultrawide w-full object-cover object-center']}
       width={1280}

--- a/src/components/ArticleImage.astro
+++ b/src/components/ArticleImage.astro
@@ -10,8 +10,8 @@
  * <ArticleImage featured={featured} />
  */
 import LinkExternal from '@components/LinkExternal.astro'
+import ResponsiveImage from '@components/ResponsiveImage.astro'
 import type { ImageMetadata } from 'astro'
-import { Image } from 'astro:assets'
 
 interface Props {
   featured: {
@@ -37,9 +37,9 @@ const alt = author ? author.name : 'unknown'
 <div id="article-featured" class:list={[className]}>
   <figure>
     <div class:list={['overflow-hidden rounded-md']}>
-      <Image
+      <ResponsiveImage
         class:list={['aspect-ultrawide object-cover object-center']}
-        src={image}
+        image={image}
         alt={alt}
         loading={'eager'}
         fetchpriority={'high'}

--- a/src/components/AuthorCard.astro
+++ b/src/components/AuthorCard.astro
@@ -10,7 +10,7 @@
  * <AuthorCard autor={entry} />
  */
 import LinkInternal from '@components/LinkInternal.astro'
-import { Image } from 'astro:assets'
+import ResponsiveImage from '@components/ResponsiveImage.astro'
 import type { CollectionEntry } from 'astro:content'
 
 interface Props {
@@ -33,8 +33,8 @@ const loading = lazy ? 'lazy' : 'eager'
       className,
     ]}
   >
-    <Image
-      src={author.data.avatar}
+    <ResponsiveImage
+      image={author.data.avatar}
       alt={author.data.name}
       width={90}
       loading={loading}

--- a/src/components/PageHeader.astro
+++ b/src/components/PageHeader.astro
@@ -9,10 +9,10 @@
  * @example
  * <PageHeader />
  */
-import { Image } from 'astro:assets'
 import type { CollectionEntry } from 'astro:content'
 import { Icon } from 'astro-icon/components'
 
+import ResponsiveImage from './ResponsiveImage.astro'
 import TypeaheadSearch from './TypeaheadSearch.astro'
 
 interface Props {
@@ -41,9 +41,9 @@ const { site, class: className } = Astro.props
                 'ring-secondary-light overflow-hidden rounded-lg ring-2',
               ]}
             >
-              <Image
-                src={site.data.avatar}
-                alt=""
+              <ResponsiveImage
+                image={site.data.avatar}
+                alt={site.data.title}
                 loading={'eager'}
                 fetchpriority={'high'}
                 width={80}

--- a/src/components/ResponsiveImage.astro
+++ b/src/components/ResponsiveImage.astro
@@ -1,0 +1,55 @@
+---
+import { createBlurDataUrl } from '@utils/image'
+import type { ImageMetadata } from 'astro'
+import { Image } from 'astro:assets'
+
+interface Props {
+  image: ImageMetadata
+  alt: string
+  title?: string
+  width: number
+  height?: number
+  widths?: number[]
+  sizes?: string
+  loading?: 'eager' | 'lazy'
+  fetchpriority?: 'auto' | 'high' | 'low'
+  decoding?: 'async' | 'auto' | 'sync'
+  class?: string
+}
+
+const {
+  image,
+  alt,
+  title,
+  width,
+  height,
+  widths,
+  sizes,
+  loading = 'lazy',
+  fetchpriority = 'low',
+  decoding = 'async',
+  class: className,
+} = Astro.props
+
+const placeholder = await createBlurDataUrl(image)
+const style = placeholder ? { backgroundImage: `url("${placeholder}")`, color: 'transparent' } : {}
+const clearPlaceholderStyles =
+  "this.style.removeProperty('background-image');this.style.removeProperty('color');"
+---
+
+<Image
+  src={image}
+  alt={alt}
+  title={title}
+  width={width}
+  height={height}
+  widths={widths}
+  sizes={sizes}
+  loading={loading}
+  fetchpriority={fetchpriority}
+  decoding={decoding}
+  class:list={['bg-cover bg-center bg-no-repeat', className]}
+  style={style}
+  onload={placeholder ? clearPlaceholderStyles : undefined}
+  onerror={placeholder ? clearPlaceholderStyles : undefined}
+/>

--- a/src/pages/author/[id].astro
+++ b/src/pages/author/[id].astro
@@ -6,6 +6,7 @@ import ArticleGrid from '@components/ArticleGrid.astro'
 import BackLink from '@components/BackLink.astro'
 import BreadcrumbHeader from '@components/BreadcrumbHeader.astro'
 import DisplayLimitAlert from '@components/DisplayLimitAlert.astro'
+import ResponsiveImage from '@components/ResponsiveImage.astro'
 import AuthorJson from '@components/seo/AuthorJson.astro'
 import BreadcrumbJson from '@components/seo/BreadcrumbJson.astro'
 import OpenGraphProfile from '@components/seo/OpenGraphProfile.astro'
@@ -14,7 +15,6 @@ import SocialBar from '@components/SocialBar.astro'
 import Layout from '@layouts/Layout.astro'
 import { getArticlesByAuthor } from '@utils/article'
 import { getDefaultSite } from '@utils/site'
-import { Image } from 'astro:assets'
 import type { CollectionEntry } from 'astro:content'
 import { getCollection } from 'astro:content'
 
@@ -75,8 +75,8 @@ const { articles, total } = await getArticlesByAuthor(author.id, limit)
         'ring-secondary-light w-[150px] min-w-[150px] overflow-hidden rounded-lg ring-2',
       ]}
     >
-      <Image
-        src={data.avatar}
+      <ResponsiveImage
+        image={data.avatar}
         alt={data.name}
         loading={'eager'}
         fetchpriority={'high'}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -20,8 +20,8 @@
 
 @theme inline {
   --font-mono:
-    var(--font-fira-code), ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-    'Liberation Mono', 'Courier New', monospace;
+    var(--font-fira-code), ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
+    'Courier New', monospace;
   --font-serif:
     var(--font-noto-serif-georgian), ui-serif, Georgia, Cambria, 'Times New Roman', Times, serif;
   --font-sans:

--- a/src/utils/feed.ts
+++ b/src/utils/feed.ts
@@ -9,6 +9,7 @@ import mime from 'mime'
 import sanitizeHtml from 'sanitize-html'
 
 import { getArticles } from './article'
+import { normalizeImageKey } from './image'
 import { buildUrl } from './misc'
 import { getDefaultSite } from './site'
 
@@ -277,9 +278,7 @@ class FeedImageCollection {
    * @returns The normalized key
    */
   private normalizeKey(key: string): string {
-    return key
-      .split('?')[0]
-      .replace('/@fs', '')
+    return normalizeImageKey(key)
       .replace(this.cwd, '')
       .replace(/^\/src\/content/, '')
       .replace(/^\/article\/(\d{4})\/([^/]+)/, (_, year, rest) => {

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -1,0 +1,157 @@
+import { createHash } from 'node:crypto'
+import { mkdir, readFile, stat, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+
+import type { ImageMetadata } from 'astro'
+import sharp from 'sharp'
+
+interface PlaceholderOptions {
+  width?: number
+  blur?: number
+  quality?: number
+}
+
+const cacheDirectory = path.join(process.cwd(), '.cache', 'image-placeholders')
+const manifestPath = path.join(cacheDirectory, 'manifest.json')
+
+type Manifest = Record<string, string>
+
+let manifestCache: Manifest | undefined
+const dataUrlCache: Map<string, string | null> = new Map()
+
+/**
+ * Normalize an image key/source by removing query params and normalizing /@fs paths.
+ *
+ * @param source - The raw image source or key.
+ * @returns normalized source key.
+ */
+export const normalizeImageKey = (source: string): string => {
+  return decodeURIComponent(source.split('?')[0]).replace('/@fs', '')
+}
+
+const sourceImageModules = import.meta.glob<ImageMetadata>(
+  '/src/**/*.{avif,gif,jpeg,jpg,png,webp}',
+  {
+    eager: true,
+    import: 'default',
+  }
+)
+
+const sourcePathByOutputSrc: Map<string, string> = new Map(
+  Object.entries(sourceImageModules).map(([sourcePath, metadata]) => [
+    normalizeImageKey(metadata.src),
+    sourcePath,
+  ])
+)
+
+const loadManifest = async (): Promise<Manifest> => {
+  if (manifestCache) {
+    return manifestCache
+  }
+
+  try {
+    const content = await readFile(manifestPath, 'utf-8')
+    manifestCache = JSON.parse(content) as Manifest
+  } catch {
+    manifestCache = {}
+  }
+
+  return manifestCache
+}
+
+const persistManifest = async (manifest: Manifest): Promise<void> => {
+  await mkdir(cacheDirectory, { recursive: true })
+  await writeFile(manifestPath, JSON.stringify(manifest), 'utf-8')
+}
+
+const toAbsoluteProjectPath = (projectPath: string): string => {
+  return path.join(process.cwd(), projectPath.replace(/^\//, ''))
+}
+
+const resolveImageSourcePath = async (image: ImageMetadata): Promise<string | null> => {
+  const normalizedSrc = normalizeImageKey(image.src)
+
+  if (normalizedSrc.startsWith('/@fs/')) {
+    return normalizedSrc.replace('/@fs', '')
+  }
+
+  const sourcePath =
+    sourcePathByOutputSrc.get(normalizedSrc) ??
+    sourcePathByOutputSrc.get(normalizedSrc.startsWith('/') ? normalizedSrc : `/${normalizedSrc}`)
+  if (sourcePath) {
+    return toAbsoluteProjectPath(sourcePath)
+  }
+
+  const fallbackPath = path.join(process.cwd(), 'dist', normalizedSrc)
+  try {
+    await stat(fallbackPath)
+    return fallbackPath
+  } catch {
+    return null
+  }
+}
+
+const buildCacheKey = async (sourcePath: string, options: Required<PlaceholderOptions>) => {
+  const sourceStat = await stat(sourcePath)
+  return createHash('sha256')
+    .update(
+      JSON.stringify({
+        blur: options.blur,
+        mtime: sourceStat.mtimeMs,
+        quality: options.quality,
+        size: sourceStat.size,
+        sourcePath: sourcePath,
+        width: options.width,
+      })
+    )
+    .digest('hex')
+}
+
+/**
+ * Create a tiny blurred image data URL placeholder.
+ *
+ * Returns null if source-path resolution or transformation fails.
+ */
+export const createBlurDataUrl = async (
+  image: ImageMetadata,
+  options: PlaceholderOptions = {}
+): Promise<string | null> => {
+  const resolvedOptions: Required<PlaceholderOptions> = {
+    blur: options.blur ?? 4,
+    quality: options.quality ?? 70,
+    width: options.width ?? 96,
+  }
+
+  try {
+    const sourcePath = await resolveImageSourcePath(image)
+    if (!sourcePath) {
+      return null
+    }
+
+    const cacheKey = await buildCacheKey(sourcePath, resolvedOptions)
+    if (dataUrlCache.has(cacheKey)) {
+      return dataUrlCache.get(cacheKey) ?? null
+    }
+
+    const manifest = await loadManifest()
+    if (manifest[cacheKey]) {
+      dataUrlCache.set(cacheKey, manifest[cacheKey])
+      return manifest[cacheKey]
+    }
+
+    const sourceBuffer = await readFile(sourcePath)
+    const blurredBuffer = await sharp(sourceBuffer)
+      .resize({ width: resolvedOptions.width, withoutEnlargement: true })
+      .blur(resolvedOptions.blur)
+      .jpeg({ quality: resolvedOptions.quality })
+      .toBuffer()
+
+    const dataUrl = `data:image/jpeg;base64,${blurredBuffer.toString('base64')}`
+    manifest[cacheKey] = dataUrl
+    dataUrlCache.set(cacheKey, dataUrl)
+    await persistManifest(manifest)
+    return dataUrl
+  } catch {
+    return null
+  }
+}

--- a/test/components/ResponsiveImage.test.ts
+++ b/test/components/ResponsiveImage.test.ts
@@ -1,0 +1,64 @@
+import { experimental_AstroContainer as AstroContainer } from 'astro/container'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const { mockCreateBlurDataUrl } = vi.hoisted(() => ({
+  mockCreateBlurDataUrl: vi.fn(),
+}))
+
+vi.mock('@utils/image', () => ({
+  createBlurDataUrl: mockCreateBlurDataUrl,
+}))
+
+import ResponsiveImage from '@components/ResponsiveImage.astro'
+
+describe('responsiveImage', () => {
+  const image = {
+    src: '/_astro/mock-image.jpg',
+    width: 1200,
+    height: 800,
+    format: 'jpg',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const render = async () => {
+    const container = await AstroContainer.create()
+    return await container.renderToString(ResponsiveImage, {
+      props: {
+        image,
+        alt: 'Mock image',
+        width: 640,
+        loading: 'lazy',
+      },
+    })
+  }
+
+  test('adds placeholder styles and cleanup handlers when blur data URL is available', async () => {
+    mockCreateBlurDataUrl.mockResolvedValue('data:image/jpeg;base64,abc123')
+
+    const html = await render()
+
+    expect(mockCreateBlurDataUrl).toHaveBeenCalledWith(image)
+    expect(html).toContain('background-image:url(&#34;data:image/jpeg;base64,abc123&#34;)')
+    expect(html).toContain('color:transparent')
+    expect(html).toContain('onload="')
+    expect(html).toContain('onerror="')
+    expect(html).toContain("removeProperty('background-image')")
+    expect(html).toContain("removeProperty('color')")
+  })
+
+  test('omits placeholder styles and cleanup handlers when no blur data URL is available', async () => {
+    mockCreateBlurDataUrl.mockResolvedValue(null)
+
+    const html = await render()
+
+    expect(mockCreateBlurDataUrl).toHaveBeenCalledWith(image)
+    expect(html).not.toContain('background-image:url(')
+    expect(html).not.toContain('color:transparent')
+    expect(html).not.toContain('onload="')
+    expect(html).not.toContain('onerror="')
+    expect(html).not.toContain("removeProperty('background-image')")
+  })
+})

--- a/test/utils/feed.test.ts
+++ b/test/utils/feed.test.ts
@@ -109,6 +109,42 @@ describe('getFeed', () => {
     expect(item.image.url).toBe('https://feed.example.com/_astro/featured-image.jpg')
     expect(item.author.name).toBe('Mock Name 1')
   })
+
+  test('preserves query strings in feed image URLs while keeping MIME type accurate', async () => {
+    mockGetArticles.mockResolvedValue([
+      {
+        id: 'mock-feed-article-query',
+        body: '![Inline image](/_astro/inline-image.jpg?v=999)',
+        data: {
+          title: 'Mock Feed Article Query',
+          description: 'Mock feed description with query image',
+          published: new Date('2026-04-11'),
+          author: { id: 'mock-author-1' },
+          featured: {
+            image: { src: '/_astro/featured-image.jpg?v=123' },
+            author: {
+              name: 'Jane Photographer',
+              url: 'https://images.example.com/jane',
+            },
+            site: {
+              name: 'Example Photos',
+              url: 'https://images.example.com',
+            },
+          },
+        },
+      },
+    ])
+
+    const feed = await getFeed()
+    const json = JSON.parse(feed.json1())
+    const item = json.items[0]
+
+    expect(item.image.url).toBe('https://feed.example.com/_astro/featured-image.jpg?v=123')
+    expect(item.image.type).toBe('image/jpeg')
+    expect(item.content_html).toContain(
+      'src="https://feed.example.com/_astro/inline-image.jpg?v=999"'
+    )
+  })
 })
 
 describe('feedInfo', () => {

--- a/test/utils/image.test.ts
+++ b/test/utils/image.test.ts
@@ -1,0 +1,27 @@
+import { createBlurDataUrl, normalizeImageKey } from '@utils/image'
+import { describe, expect, test } from 'vitest'
+
+describe('normalizeImageKey', () => {
+  test('removes query strings and decodes URL-encoded paths', () => {
+    expect(normalizeImageKey('/_astro/my%20image.jpg?v=123')).toBe('/_astro/my image.jpg')
+  })
+
+  test('normalizes /@fs sources to absolute filesystem paths', () => {
+    expect(
+      normalizeImageKey('/@fs/Users/example/project/src/content/article/image.jpg?import')
+    ).toBe('/Users/example/project/src/content/article/image.jpg')
+  })
+})
+
+describe('createBlurDataUrl', () => {
+  test('returns null when the source image path cannot be resolved', async () => {
+    const result = await createBlurDataUrl({
+      src: '/_astro/does-not-exist.jpg',
+      width: 100,
+      height: 80,
+      format: 'jpg',
+    })
+
+    expect(result).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Introduce a reusable `ResponsiveImage` component with blurred placeholder support and switch key UI surfaces to use it. Add shared image-key normalization so feed image resolution and utility logic stay consistent, and add targeted tests for component + utility behavior.

## Linked issue

#683 

## Type of change

_Put an `x` in the boxes that apply._

- [ ] Bug fix
- [x] Feature
- [x] Maintenance / cleanup
- [ ] Documentation / content
- [ ] Breaking change

## Details

- Added `src/components/ResponsiveImage.astro`:
  - Generates blur placeholder via `createBlurDataUrl`.
  - Clears placeholder styles on `load`/`error` when a placeholder exists.
- Added `src/utils/image.ts`:
  - `normalizeImageKey` for shared source normalization.
  - Placeholder generation with cache manifest under `.cache/image-placeholders`.
- Switched major image renderers to `ResponsiveImage`:
  - `ArticleCard`, `ArticleCardLead`, `ArticleImage`, `AuthorCard`, `PageHeader`, `pages/author/[id]`.
- Updated feed normalization to use shared `normalizeImageKey`.
- Added tests:
  - `test/components/ResponsiveImage.test.ts`
  - `test/utils/image.test.ts`
  - Expanded `test/utils/feed.test.ts` for query-string image URL + MIME behavior.

## Release / deploy impact

_Put an `x` in the boxes that apply._

- [x] Preview deploy is useful for reviewing this change
- [ ] Safe to label `no-deploy`
- [x] This PR intentionally updates the version in `package.json`

## Validation

_Put an `x` in the boxes that apply._

- [x] Lint passes locally
- [x] Unit tests pass locally
- [x] Added or updated tests where appropriate
- [x] Manually verified changes
- [ ] Documentation updated where appropriate

## Reviewer notes

Validation run included:
- `pnpm run lint:fix`
- `pnpm run format:fix`
- `pnpm test -- test/components/ResponsiveImage.test.ts test/utils/image.test.ts test/utils/feed.test.ts`