### PR TITLE
feat(theme): add dark mode support and persistent theme switcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agingdeveloper",
   "private": true,
   "description": "The personal site of Richard Klein",
-  "version": "6.4.0",
+  "version": "6.5.0",
   "type": "module",
   "packageManager": "pnpm@10.24.0",
   "scripts": {

--- a/src/components/ArticleByLine.astro
+++ b/src/components/ArticleByLine.astro
@@ -21,15 +21,10 @@ interface Props {
 const { author, published, class: className } = Astro.props
 ---
 
-<address
-  id="article-byline"
-  class:list={['text-base text-stone-900/85 dark:text-stone-300', className]}
->
+<address id="article-byline" class:list={['text-fg-dark/85 text-base', className]}>
   <LinkInternal
     to={`/author/${author.id}`}
-    class:list={[
-      'mr-2 inline-block text-inherit underline hover:text-stone-900 dark:hover:text-stone-100',
-    ]}
+    class:list={['hover:text-fg-light mr-2 inline-block text-inherit underline']}
   >
     {author.data.name}
   </LinkInternal>

--- a/src/components/ArticleByLine.astro
+++ b/src/components/ArticleByLine.astro
@@ -21,8 +21,16 @@ interface Props {
 const { author, published, class: className } = Astro.props
 ---
 
-<address id="article-byline" class:list={['text-base text-stone-900/85', className]}>
-  <LinkInternal to={`/author/${author.id}`} class:list={['mr-2 inline-block underline']}>
+<address
+  id="article-byline"
+  class:list={['text-base text-stone-900/85 dark:text-stone-300', className]}
+>
+  <LinkInternal
+    to={`/author/${author.id}`}
+    class:list={[
+      'mr-2 inline-block text-inherit underline hover:text-stone-900 dark:hover:text-stone-100',
+    ]}
+  >
     {author.data.name}
   </LinkInternal>
   <time datetime={published.toISOString()}>

--- a/src/components/ArticleCard.astro
+++ b/src/components/ArticleCard.astro
@@ -29,7 +29,7 @@ const loading = lazy ? 'lazy' : 'eager'
 <LinkInternal to={`/article/${article.id}`}>
   <article
     class:list={[
-      'border-border-light bg-card-light overflow-hidden rounded-md border',
+      'border-stroke-light bg-card-light overflow-hidden rounded-md border',
       'xl:flex xl:max-h-60 xl:flex-row-reverse',
       'hover:bg-card-main hover:shadow-xs',
       'focus:bg-card-main focus:shadow-xs',

--- a/src/components/ArticleCard.astro
+++ b/src/components/ArticleCard.astro
@@ -29,12 +29,10 @@ const loading = lazy ? 'lazy' : 'eager'
 <LinkInternal to={`/article/${article.id}`}>
   <article
     class:list={[
-      'dark:border-primary-light/35 dark:bg-primary-main/35 overflow-hidden rounded-md border border-stone-300 bg-white',
+      'border-border-light bg-card-light overflow-hidden rounded-md border',
       'xl:flex xl:max-h-60 xl:flex-row-reverse',
-      'hover:bg-stone-100/85 hover:shadow-xs',
-      'dark:hover:bg-primary-main/55',
-      'focus:bg-stone-100/85 focus:shadow-xs',
-      'dark:focus:bg-primary-main/55',
+      'hover:bg-card-main hover:shadow-xs',
+      'focus:bg-card-main focus:shadow-xs',
       className,
     ]}
   >
@@ -61,15 +59,15 @@ const loading = lazy ? 'lazy' : 'eager'
       ]}
     />
     <div class:list={['px-4 pt-3 pb-2']}>
-      <h4 class:list={['text-lg leading-snug font-medium text-stone-900 dark:text-stone-100']}>
+      <h4 class:list={['text-fg-light text-lg leading-snug font-medium']}>
         {article.data.title}
       </h4>
-      <small class:list={['text-sm text-stone-600 dark:text-stone-300']}>
+      <small class:list={['text-fg-main text-sm']}>
         <time datetime={article.data.published.toISOString()}>
           {formatDate(article.data.published)}
         </time>
       </small>
-      <p class:list={['text-md mt-2 leading-relaxed text-stone-700 dark:text-stone-200']}>
+      <p class:list={['text-md text-fg-dark mt-2 leading-relaxed']}>
         {frontmatter.excerpt}&hellip;
       </p>
     </div>

--- a/src/components/ArticleCard.astro
+++ b/src/components/ArticleCard.astro
@@ -29,10 +29,12 @@ const loading = lazy ? 'lazy' : 'eager'
 <LinkInternal to={`/article/${article.id}`}>
   <article
     class:list={[
-      'overflow-hidden rounded-md border border-stone-300 bg-white',
+      'dark:border-primary-light/35 dark:bg-primary-main/35 overflow-hidden rounded-md border border-stone-300 bg-white',
       'xl:flex xl:max-h-60 xl:flex-row-reverse',
       'hover:bg-stone-100/85 hover:shadow-xs',
+      'dark:hover:bg-primary-main/55',
       'focus:bg-stone-100/85 focus:shadow-xs',
+      'dark:focus:bg-primary-main/55',
       className,
     ]}
   >
@@ -59,15 +61,15 @@ const loading = lazy ? 'lazy' : 'eager'
       ]}
     />
     <div class:list={['px-4 pt-3 pb-2']}>
-      <h4 class:list={['text-lg leading-snug font-medium text-stone-900']}>
+      <h4 class:list={['text-lg leading-snug font-medium text-stone-900 dark:text-stone-100']}>
         {article.data.title}
       </h4>
-      <small class:list={['text-sm text-stone-600']}>
+      <small class:list={['text-sm text-stone-600 dark:text-stone-300']}>
         <time datetime={article.data.published.toISOString()}>
           {formatDate(article.data.published)}
         </time>
       </small>
-      <p class:list={['text-md mt-2 leading-relaxed text-stone-700']}>
+      <p class:list={['text-md mt-2 leading-relaxed text-stone-700 dark:text-stone-200']}>
         {frontmatter.excerpt}&hellip;
       </p>
     </div>

--- a/src/components/ArticleCardLead.astro
+++ b/src/components/ArticleCardLead.astro
@@ -28,10 +28,12 @@ const { remarkPluginFrontmatter: frontmatter } = await render(article)
   <article
     id="article-card-lead"
     class:list={[
-      'overflow-hidden rounded-md border border-stone-300 bg-white',
+      'dark:border-primary-light/35 dark:bg-primary-main/35 overflow-hidden rounded-md border border-stone-300 bg-white',
       'hover:bg-stone-100/85 hover:shadow-xs',
+      'dark:hover:bg-primary-main/55',
       'focus:bg-stone-100/85 focus:shadow-xs',
-      'lg:relative lg:bg-white',
+      'dark:focus:bg-primary-main/55',
+      'dark:lg:bg-primary-main/35 lg:relative lg:bg-white',
       className,
     ]}
   >
@@ -53,7 +55,7 @@ const { remarkPluginFrontmatter: frontmatter } = await render(article)
     />
     <div
       class:list={[
-        'w-full bg-white lg:bg-transparent',
+        'dark:bg-primary-main/35 w-full bg-white lg:bg-transparent dark:lg:bg-transparent',
         'lg:absolute lg:top-0 lg:left-0 lg:h-full',
         'lg:from-primary-main/75 lg:via-primary-main/60 lg:bg-linear-to-r lg:to-transparent',
       ]}
@@ -61,7 +63,7 @@ const { remarkPluginFrontmatter: frontmatter } = await render(article)
       <div class:list={['w-full px-4 pt-3 pb-2', 'lg:p-8', 'lg:w-3/5']}>
         <h4
           class:list={[
-            'text-lg leading-snug font-medium text-stone-900',
+            'text-lg leading-snug font-medium text-stone-900 dark:text-stone-100',
             'lg:text-primary-contrast lg:text-4xl',
             'lg:drop-shadow-lg',
           ]}
@@ -70,7 +72,7 @@ const { remarkPluginFrontmatter: frontmatter } = await render(article)
         </h4>
         <small
           class:list={[
-            'text-sm text-stone-600',
+            'text-sm text-stone-600 dark:text-stone-300',
             'lg:text-primary-contrast lg:text-lg',
             'lg:drop-shadow-md',
           ]}
@@ -81,7 +83,7 @@ const { remarkPluginFrontmatter: frontmatter } = await render(article)
         </small>
         <p
           class:list={[
-            'text-md mt-2 leading-relaxed text-stone-700',
+            'text-md mt-2 leading-relaxed text-stone-700 dark:text-stone-200',
             'lg:text-primary-contrast lg:mt-6 lg:text-lg',
             'lg:mt-8',
             'lg:drop-shadow-md',

--- a/src/components/ArticleCardLead.astro
+++ b/src/components/ArticleCardLead.astro
@@ -28,12 +28,10 @@ const { remarkPluginFrontmatter: frontmatter } = await render(article)
   <article
     id="article-card-lead"
     class:list={[
-      'dark:border-primary-light/35 dark:bg-primary-main/35 overflow-hidden rounded-md border border-stone-300 bg-white',
-      'hover:bg-stone-100/85 hover:shadow-xs',
-      'dark:hover:bg-primary-main/55',
-      'focus:bg-stone-100/85 focus:shadow-xs',
-      'dark:focus:bg-primary-main/55',
-      'dark:lg:bg-primary-main/35 lg:relative lg:bg-white',
+      'border-border-light bg-card-light overflow-hidden rounded-md border',
+      'hover:bg-card-main hover:shadow-xs',
+      'focus:bg-card-main focus:shadow-xs',
+      'lg:bg-card-light lg:relative',
       className,
     ]}
   >
@@ -55,7 +53,7 @@ const { remarkPluginFrontmatter: frontmatter } = await render(article)
     />
     <div
       class:list={[
-        'dark:bg-primary-main/35 w-full bg-white lg:bg-transparent dark:lg:bg-transparent',
+        'bg-card-light w-full lg:bg-transparent',
         'lg:absolute lg:top-0 lg:left-0 lg:h-full',
         'lg:from-primary-main/75 lg:via-primary-main/60 lg:bg-linear-to-r lg:to-transparent',
       ]}
@@ -63,7 +61,7 @@ const { remarkPluginFrontmatter: frontmatter } = await render(article)
       <div class:list={['w-full px-4 pt-3 pb-2', 'lg:p-8', 'lg:w-3/5']}>
         <h4
           class:list={[
-            'text-lg leading-snug font-medium text-stone-900 dark:text-stone-100',
+            'text-fg-light text-lg leading-snug font-medium',
             'lg:text-primary-contrast lg:text-4xl',
             'lg:drop-shadow-lg',
           ]}
@@ -72,7 +70,7 @@ const { remarkPluginFrontmatter: frontmatter } = await render(article)
         </h4>
         <small
           class:list={[
-            'text-sm text-stone-600 dark:text-stone-300',
+            'text-fg-main text-sm',
             'lg:text-primary-contrast lg:text-lg',
             'lg:drop-shadow-md',
           ]}
@@ -83,7 +81,7 @@ const { remarkPluginFrontmatter: frontmatter } = await render(article)
         </small>
         <p
           class:list={[
-            'text-md mt-2 leading-relaxed text-stone-700 dark:text-stone-200',
+            'text-md text-fg-dark mt-2 leading-relaxed',
             'lg:text-primary-contrast lg:mt-6 lg:text-lg',
             'lg:mt-8',
             'lg:drop-shadow-md',

--- a/src/components/ArticleCardLead.astro
+++ b/src/components/ArticleCardLead.astro
@@ -28,7 +28,7 @@ const { remarkPluginFrontmatter: frontmatter } = await render(article)
   <article
     id="article-card-lead"
     class:list={[
-      'border-border-light bg-card-light overflow-hidden rounded-md border',
+      'border-stroke-light bg-card-light overflow-hidden rounded-md border',
       'hover:bg-card-main hover:shadow-xs',
       'focus:bg-card-main focus:shadow-xs',
       'lg:bg-card-light lg:relative',

--- a/src/components/ArticleImage.astro
+++ b/src/components/ArticleImage.astro
@@ -57,11 +57,11 @@ const alt = author ? author.name : 'unknown'
     {
       author || site ? (
         <figcaption>
-          <small class:list={['mt-1 text-sm text-stone-700/85 dark:text-stone-300']}>
+          <small class:list={['text-fg-dark/85 mt-1 text-sm']}>
             {author ? (
               <>
                 {'Image by '}
-                <LinkExternal class:list={['underline dark:text-stone-100']} to={author.url}>
+                <LinkExternal class:list={['text-fg-light underline']} to={author.url}>
                   {author.name}
                 </LinkExternal>
               </>
@@ -69,7 +69,7 @@ const alt = author ? author.name : 'unknown'
             {site ? (
               <>
                 {' on '}
-                <LinkExternal class:list={['underline dark:text-stone-100']} to={site.url}>
+                <LinkExternal class:list={['text-fg-light underline']} to={site.url}>
                   {site.name}
                 </LinkExternal>
               </>

--- a/src/components/ArticleImage.astro
+++ b/src/components/ArticleImage.astro
@@ -57,11 +57,11 @@ const alt = author ? author.name : 'unknown'
     {
       author || site ? (
         <figcaption>
-          <small class:list={['mt-1 text-sm text-stone-700/85']}>
+          <small class:list={['mt-1 text-sm text-stone-700/85 dark:text-stone-300']}>
             {author ? (
               <>
                 {'Image by '}
-                <LinkExternal class:list={['underline']} to={author.url}>
+                <LinkExternal class:list={['underline dark:text-stone-100']} to={author.url}>
                   {author.name}
                 </LinkExternal>
               </>
@@ -69,7 +69,7 @@ const alt = author ? author.name : 'unknown'
             {site ? (
               <>
                 {' on '}
-                <LinkExternal class:list={['underline']} to={site.url}>
+                <LinkExternal class:list={['underline dark:text-stone-100']} to={site.url}>
                   {site.name}
                 </LinkExternal>
               </>

--- a/src/components/ArticleLicense.astro
+++ b/src/components/ArticleLicense.astro
@@ -30,9 +30,9 @@ const licenseLabel = license.short ?? license.name
 
 <div
   class:list={[
-    'rounded-md border border-stone-500',
+    'rounded-md border border-stone-500 dark:border-stone-600',
     'px-3 py-2',
-    'flex items-center gap-3',
+    'flex items-center gap-3 text-stone-900 dark:text-stone-200',
     className,
   ]}
 >
@@ -47,14 +47,18 @@ const licenseLabel = license.short ?? license.name
             aria-label={licenseLabel}
           />
         </div>
-        <div class="h-10 w-px bg-stone-200" aria-hidden="true" />
+        <div class="h-10 w-px bg-stone-200 dark:bg-stone-700" aria-hidden="true" />
       </>
     )
   }
   <div class="text-sm">
     {'This article is licensed under '}
-    <LinkExternal to={license.url} title={licenseLabel} class:list={['text-stone-700 underline']}
-      >{license.name}</LinkExternal
-    >{'.'}
+    <LinkExternal
+      to={license.url}
+      title={licenseLabel}
+      class:list={['text-stone-700 underline dark:text-stone-100']}
+    >
+      {license.name}
+    </LinkExternal>{'.'}
   </div>
 </div>

--- a/src/components/ArticleLicense.astro
+++ b/src/components/ArticleLicense.astro
@@ -30,7 +30,7 @@ const licenseLabel = license.short ?? license.name
 
 <div
   class:list={[
-    'border-border-main rounded-md border',
+    'border-stroke-main rounded-md border',
     'px-3 py-2',
     'text-fg-light flex items-center gap-3',
     className,
@@ -47,7 +47,7 @@ const licenseLabel = license.short ?? license.name
             aria-label={licenseLabel}
           />
         </div>
-        <div class="bg-border-light h-10 w-px" aria-hidden="true" />
+        <div class="bg-stroke-light h-10 w-px" aria-hidden="true" />
       </>
     )
   }

--- a/src/components/ArticleLicense.astro
+++ b/src/components/ArticleLicense.astro
@@ -30,9 +30,9 @@ const licenseLabel = license.short ?? license.name
 
 <div
   class:list={[
-    'rounded-md border border-stone-500 dark:border-stone-600',
+    'border-border-main rounded-md border',
     'px-3 py-2',
-    'flex items-center gap-3 text-stone-900 dark:text-stone-200',
+    'text-fg-light flex items-center gap-3',
     className,
   ]}
 >
@@ -47,17 +47,13 @@ const licenseLabel = license.short ?? license.name
             aria-label={licenseLabel}
           />
         </div>
-        <div class="h-10 w-px bg-stone-200 dark:bg-stone-700" aria-hidden="true" />
+        <div class="bg-border-light h-10 w-px" aria-hidden="true" />
       </>
     )
   }
   <div class="text-sm">
     {'This article is licensed under '}
-    <LinkExternal
-      to={license.url}
-      title={licenseLabel}
-      class:list={['text-stone-700 underline dark:text-stone-100']}
-    >
+    <LinkExternal to={license.url} title={licenseLabel} class:list={['text-fg-dark underline']}>
       {license.name}
     </LinkExternal>{'.'}
   </div>

--- a/src/components/ArticleTitle.astro
+++ b/src/components/ArticleTitle.astro
@@ -19,6 +19,6 @@ const { title, description, class: className } = Astro.props
 ---
 
 <hgroup id="article-title" class:list={[className]}>
-  <h2 class:list={['text-5xl leading-snug text-stone-900 dark:text-stone-100']}>{title}</h2>
-  <h3 class:list={['text-lg leading-tight text-stone-700 dark:text-stone-300']}>{description}</h3>
+  <h2 class:list={['text-fg-light text-5xl leading-snug']}>{title}</h2>
+  <h3 class:list={['text-fg-main text-lg leading-tight']}>{description}</h3>
 </hgroup>

--- a/src/components/ArticleTitle.astro
+++ b/src/components/ArticleTitle.astro
@@ -19,6 +19,6 @@ const { title, description, class: className } = Astro.props
 ---
 
 <hgroup id="article-title" class:list={[className]}>
-  <h2 class:list={['text-5xl leading-snug']}>{title}</h2>
-  <h3 class:list={['text-lg leading-tight']}>{description}</h3>
+  <h2 class:list={['text-5xl leading-snug text-stone-900 dark:text-stone-100']}>{title}</h2>
+  <h3 class:list={['text-lg leading-tight text-stone-700 dark:text-stone-300']}>{description}</h3>
 </hgroup>

--- a/src/components/AuthorCard.astro
+++ b/src/components/AuthorCard.astro
@@ -26,12 +26,10 @@ const loading = lazy ? 'lazy' : 'eager'
 <LinkInternal to={`/author/${author.id}`}>
   <div
     class:list={[
-      'dark:border-primary-light/35 dark:bg-primary-main/35 overflow-hidden rounded-md border border-stone-300 bg-white',
+      'border-border-light bg-card-light overflow-hidden rounded-md border',
       'flex max-h-[120px]',
-      'hover:bg-stone-100/85 hover:shadow-xs',
-      'dark:hover:bg-primary-main/55',
-      'focus:bg-stone-100/85 focus:shadow-xs',
-      'dark:focus:bg-primary-main/55',
+      'hover:bg-card-main hover:shadow-xs',
+      'focus:bg-card-main focus:shadow-xs',
       className,
     ]}
   >
@@ -43,10 +41,10 @@ const loading = lazy ? 'lazy' : 'eager'
       class:list={['object-cover object-center', 'aspect-3/4 w-[90px] xl:min-w-[90px]']}
     />
     <div class:list={['px-4 pt-3 pb-2']}>
-      <h4 class:list={['text-lg leading-snug font-medium text-stone-900 dark:text-stone-100']}>
+      <h4 class:list={['text-fg-light text-lg leading-snug font-medium']}>
         {author.data.name}
       </h4>
-      <p class:list={['text-md leading-relaxed text-stone-600 md:text-lg dark:text-stone-300']}>
+      <p class:list={['text-md text-fg-main leading-relaxed md:text-lg']}>
         {author.data.tagline}
       </p>
     </div>

--- a/src/components/AuthorCard.astro
+++ b/src/components/AuthorCard.astro
@@ -26,7 +26,7 @@ const loading = lazy ? 'lazy' : 'eager'
 <LinkInternal to={`/author/${author.id}`}>
   <div
     class:list={[
-      'border-border-light bg-card-light overflow-hidden rounded-md border',
+      'border-stroke-light bg-card-light overflow-hidden rounded-md border',
       'flex max-h-[120px]',
       'hover:bg-card-main hover:shadow-xs',
       'focus:bg-card-main focus:shadow-xs',

--- a/src/components/AuthorCard.astro
+++ b/src/components/AuthorCard.astro
@@ -26,10 +26,12 @@ const loading = lazy ? 'lazy' : 'eager'
 <LinkInternal to={`/author/${author.id}`}>
   <div
     class:list={[
-      'overflow-hidden rounded-md border border-stone-300 bg-white',
+      'dark:border-primary-light/35 dark:bg-primary-main/35 overflow-hidden rounded-md border border-stone-300 bg-white',
       'flex max-h-[120px]',
       'hover:bg-stone-100/85 hover:shadow-xs',
+      'dark:hover:bg-primary-main/55',
       'focus:bg-stone-100/85 focus:shadow-xs',
+      'dark:focus:bg-primary-main/55',
       className,
     ]}
   >
@@ -41,10 +43,10 @@ const loading = lazy ? 'lazy' : 'eager'
       class:list={['object-cover object-center', 'aspect-3/4 w-[90px] xl:min-w-[90px]']}
     />
     <div class:list={['px-4 pt-3 pb-2']}>
-      <h4 class:list={['text-lg leading-snug font-medium text-stone-900']}>
+      <h4 class:list={['text-lg leading-snug font-medium text-stone-900 dark:text-stone-100']}>
         {author.data.name}
       </h4>
-      <p class:list={['text-md leading-relaxed text-stone-600 md:text-lg']}>
+      <p class:list={['text-md leading-relaxed text-stone-600 md:text-lg dark:text-stone-300']}>
         {author.data.tagline}
       </p>
     </div>

--- a/src/components/BreadcrumbHeader.astro
+++ b/src/components/BreadcrumbHeader.astro
@@ -26,22 +26,13 @@ const { head, tail, class: className } = Astro.props
 ---
 
 <header class:list={['flex w-full items-center', className]}>
-  <span class:list={['mr-2 h-px grow rounded-sm bg-stone-300 dark:bg-stone-500']}></span>
-  <ol
-    class:list={[
-      'inline-flex items-center space-x-0 md:space-x-3',
-      'text-stone-900 capitalize dark:text-stone-200',
-    ]}
-  >
+  <span class:list={['bg-border-light mr-2 h-px grow rounded-sm']}></span>
+  <ol class:list={['inline-flex items-center space-x-0 md:space-x-3', 'text-fg-light capitalize']}>
     {
       tail == null ? (
         <li>{head.name}</li>
       ) : (
-        <li
-          class:list={[
-            "after:mx-1 after:text-stone-300 after:content-['/'] dark:after:text-stone-400",
-          ]}
-        >
+        <li class:list={["after:text-border-light after:mx-1 after:content-['/']"]}>
           <LinkInternal to={head.path} class:list={['hover:underline', 'text-inherit']}>
             {head.name}
           </LinkInternal>
@@ -50,5 +41,5 @@ const { head, tail, class: className } = Astro.props
     }
     {tail ? <li>{tail}</li> : null}
   </ol>
-  <span class:list={['ml-2 h-px grow rounded-sm bg-stone-300 dark:bg-stone-500']}></span>
+  <span class:list={['bg-border-light ml-2 h-px grow rounded-sm']}></span>
 </header>

--- a/src/components/BreadcrumbHeader.astro
+++ b/src/components/BreadcrumbHeader.astro
@@ -26,13 +26,13 @@ const { head, tail, class: className } = Astro.props
 ---
 
 <header class:list={['flex w-full items-center', className]}>
-  <span class:list={['bg-border-light mr-2 h-px grow rounded-sm']}></span>
+  <span class:list={['bg-stroke-light mr-2 h-px grow rounded-sm']}></span>
   <ol class:list={['inline-flex items-center space-x-0 md:space-x-3', 'text-fg-light capitalize']}>
     {
       tail == null ? (
         <li>{head.name}</li>
       ) : (
-        <li class:list={["after:text-border-light after:mx-1 after:content-['/']"]}>
+        <li class:list={["after:text-stroke-light after:mx-1 after:content-['/']"]}>
           <LinkInternal to={head.path} class:list={['hover:underline', 'text-inherit']}>
             {head.name}
           </LinkInternal>
@@ -41,5 +41,5 @@ const { head, tail, class: className } = Astro.props
     }
     {tail ? <li>{tail}</li> : null}
   </ol>
-  <span class:list={['bg-border-light ml-2 h-px grow rounded-sm']}></span>
+  <span class:list={['bg-stroke-light ml-2 h-px grow rounded-sm']}></span>
 </header>

--- a/src/components/BreadcrumbHeader.astro
+++ b/src/components/BreadcrumbHeader.astro
@@ -26,13 +26,22 @@ const { head, tail, class: className } = Astro.props
 ---
 
 <header class:list={['flex w-full items-center', className]}>
-  <span class:list={['mr-2 h-px grow rounded-sm bg-stone-300']}></span>
-  <ol class:list={['inline-flex items-center space-x-0 md:space-x-3', 'text-stone-900 capitalize']}>
+  <span class:list={['mr-2 h-px grow rounded-sm bg-stone-300 dark:bg-stone-500']}></span>
+  <ol
+    class:list={[
+      'inline-flex items-center space-x-0 md:space-x-3',
+      'text-stone-900 capitalize dark:text-stone-200',
+    ]}
+  >
     {
       tail == null ? (
         <li>{head.name}</li>
       ) : (
-        <li class:list={["after:mx-1 after:text-stone-300 after:content-['/']"]}>
+        <li
+          class:list={[
+            "after:mx-1 after:text-stone-300 after:content-['/'] dark:after:text-stone-400",
+          ]}
+        >
           <LinkInternal to={head.path} class:list={['hover:underline', 'text-inherit']}>
             {head.name}
           </LinkInternal>
@@ -41,5 +50,5 @@ const { head, tail, class: className } = Astro.props
     }
     {tail ? <li>{tail}</li> : null}
   </ol>
-  <span class:list={['ml-2 h-px grow rounded-sm bg-stone-300']}></span>
+  <span class:list={['ml-2 h-px grow rounded-sm bg-stone-300 dark:bg-stone-500']}></span>
 </header>

--- a/src/components/PageFooter.astro
+++ b/src/components/PageFooter.astro
@@ -30,16 +30,12 @@ const year = new Date().getFullYear()
         <LinkExternal
           to={'/rss.xml'}
           title={`${site.data.title} - RSS`}
-          class:list={[
-            'block rounded-full p-2',
-            'hover:bg-stone-100 focus:bg-stone-300',
-            'dark:hover:bg-primary-main/70 dark:focus:bg-primary-main',
-          ]}
+          class:list={['block rounded-full p-2', 'hover:bg-card-main focus:bg-card-dark']}
         >
           <Icon
             name="mdi:rss-feed"
             title={`${site.data.title} - RSS`}
-            class:list={['text-primary-main dark:text-primary-contrast h-6 w-6']}
+            class:list={['text-icon-main h-6 w-6']}
           />
         </LinkExternal>
       </li>
@@ -47,16 +43,12 @@ const year = new Date().getFullYear()
         <LinkExternal
           to={site.data.repository}
           title={`${site.data.title} - Repository`}
-          class:list={[
-            'block rounded-full p-2',
-            'hover:bg-stone-100 focus:bg-stone-300',
-            'dark:hover:bg-primary-main/70 dark:focus:bg-primary-main',
-          ]}
+          class:list={['block rounded-full p-2', 'hover:bg-card-main focus:bg-card-dark']}
         >
           <Icon
             name="mdi:github"
             title={`${site.data.title} - Repository`}
-            class:list={['text-primary-main dark:text-primary-contrast h-6 w-6']}
+            class:list={['text-icon-main h-6 w-6']}
           />
         </LinkExternal>
       </li>

--- a/src/components/PageFooter.astro
+++ b/src/components/PageFooter.astro
@@ -10,6 +10,7 @@
  * <PageFooter />
  */
 import LinkExternal from '@components/LinkExternal.astro'
+import ThemeSwitcher from '@components/ThemeSwitcher.astro'
 import type { CollectionEntry } from 'astro:content'
 import { Icon } from 'astro-icon/components'
 
@@ -29,12 +30,16 @@ const year = new Date().getFullYear()
         <LinkExternal
           to={'/rss.xml'}
           title={`${site.data.title} - RSS`}
-          class:list={['block rounded-full p-2', 'hover:bg-stone-100 focus:bg-stone-300']}
+          class:list={[
+            'block rounded-full p-2',
+            'hover:bg-stone-100 focus:bg-stone-300',
+            'dark:hover:bg-primary-main/70 dark:focus:bg-primary-main',
+          ]}
         >
           <Icon
             name="mdi:rss-feed"
             title={`${site.data.title} - RSS`}
-            class:list={['text-primary-main h-6 w-6']}
+            class:list={['text-primary-main dark:text-primary-contrast h-6 w-6']}
           />
         </LinkExternal>
       </li>
@@ -42,14 +47,21 @@ const year = new Date().getFullYear()
         <LinkExternal
           to={site.data.repository}
           title={`${site.data.title} - Repository`}
-          class:list={['block rounded-full p-2', 'hover:bg-stone-100 focus:bg-stone-300']}
+          class:list={[
+            'block rounded-full p-2',
+            'hover:bg-stone-100 focus:bg-stone-300',
+            'dark:hover:bg-primary-main/70 dark:focus:bg-primary-main',
+          ]}
         >
           <Icon
             name="mdi:github"
             title={`${site.data.title} - Repository`}
-            class:list={['text-primary-main h-6 w-6']}
+            class:list={['text-primary-main dark:text-primary-contrast h-6 w-6']}
           />
         </LinkExternal>
+      </li>
+      <li class="ml-6">
+        <ThemeSwitcher />
       </li>
     </ol>
   </div>

--- a/src/components/SocialBar.astro
+++ b/src/components/SocialBar.astro
@@ -32,16 +32,12 @@ const { socials, class: className } = Astro.props
           <LinkExternal
             to={social.url}
             title={social.name}
-            class:list={[
-              'block rounded-full p-2',
-              'hover:bg-stone-100 focus:bg-stone-300',
-              'dark:hover:bg-primary-main/70 dark:focus:bg-primary-main',
-            ]}
+            class:list={['block rounded-full p-2', 'hover:bg-card-main focus:bg-card-dark']}
           >
             <Icon
               name={`mdi:${social.name.toLowerCase()}`}
               title={social.name}
-              class:list={['text-primary-main dark:text-primary-contrast h-6 w-6']}
+              class:list={['text-icon-main h-6 w-6']}
             />
           </LinkExternal>
         </li>

--- a/src/components/SocialBar.astro
+++ b/src/components/SocialBar.astro
@@ -32,12 +32,16 @@ const { socials, class: className } = Astro.props
           <LinkExternal
             to={social.url}
             title={social.name}
-            class:list={['block rounded-full p-2', 'hover:bg-stone-100 focus:bg-stone-300']}
+            class:list={[
+              'block rounded-full p-2',
+              'hover:bg-stone-100 focus:bg-stone-300',
+              'dark:hover:bg-primary-main/70 dark:focus:bg-primary-main',
+            ]}
           >
             <Icon
               name={`mdi:${social.name.toLowerCase()}`}
               title={social.name}
-              class:list={['text-primary-main h-6 w-6']}
+              class:list={['text-primary-main dark:text-primary-contrast h-6 w-6']}
             />
           </LinkExternal>
         </li>

--- a/src/components/TagGridLink.astro
+++ b/src/components/TagGridLink.astro
@@ -41,8 +41,8 @@ const pathPrefix = isCategory ? '/category' : '/tag'
   to={`${pathPrefix}/${slugify(name)}`}
   class:list={[
     'justify-left m-0 inline-flex items-center px-2 py-1',
-    'text-stone-900 capitalize',
-    'hover:underline focus:underline',
+    'text-stone-900 capitalize dark:text-stone-200',
+    'hover:underline focus:underline dark:hover:text-stone-100 dark:focus:text-stone-100',
     cssNames.get(weight),
     className,
   ]}

--- a/src/components/TagGridLink.astro
+++ b/src/components/TagGridLink.astro
@@ -41,8 +41,8 @@ const pathPrefix = isCategory ? '/category' : '/tag'
   to={`${pathPrefix}/${slugify(name)}`}
   class:list={[
     'justify-left m-0 inline-flex items-center px-2 py-1',
-    'text-stone-900 capitalize dark:text-stone-200',
-    'hover:underline focus:underline dark:hover:text-stone-100 dark:focus:text-stone-100',
+    'text-fg-light capitalize',
+    'hover:text-fg-light focus:text-fg-light hover:underline focus:underline',
     cssNames.get(weight),
     className,
   ]}

--- a/src/components/ThemeSwitcher.astro
+++ b/src/components/ThemeSwitcher.astro
@@ -22,8 +22,8 @@ import { Icon } from 'astro-icon/components'
       aria-label="Theme"
       class:list={[
         'appearance-none rounded-lg border px-3 py-2.5 pr-9 pl-10 text-sm shadow-inner',
-        'focus:border-border-main focus:ring-border-light/70 focus:ring-2 focus:outline-hidden',
-        'text-fg-light border-border-light bg-card-light backdrop-blur-xs',
+        'focus:border-stroke-main focus:ring-stroke-light/70 focus:ring-2 focus:outline-hidden',
+        'text-fg-light border-stroke-light bg-card-light backdrop-blur-xs',
       ]}
     >
       <option value="system">System</option>

--- a/src/components/ThemeSwitcher.astro
+++ b/src/components/ThemeSwitcher.astro
@@ -1,0 +1,138 @@
+---
+import { Icon } from 'astro-icon/components'
+---
+
+<theme-switcher>
+  <div class="relative">
+    <div class="pointer-events-none absolute top-1/2 left-3 z-10 -translate-y-1/2">
+      <Icon
+        name="mdi:monitor"
+        data-theme-icon="system"
+        class:list={['h-5 w-5 text-stone-500 dark:text-white/70']}
+      />
+      <Icon
+        name="mdi:white-balance-sunny"
+        data-theme-icon="light"
+        class:list={['hidden h-5 w-5 text-stone-500 dark:text-white/70']}
+      />
+      <Icon
+        name="mdi:moon-waning-crescent"
+        data-theme-icon="dark"
+        class:list={['hidden h-5 w-5 text-stone-500 dark:text-white/70']}
+      />
+    </div>
+    <select
+      data-theme-select
+      aria-label="Theme"
+      class:list={[
+        'appearance-none rounded-lg border px-3 py-2.5 pr-9 pl-10 text-sm shadow-inner',
+        'focus:border-stone-400 focus:ring-2 focus:ring-stone-300/70 focus:outline-hidden',
+        'text-primary-main border-stone-300 bg-white',
+        'dark:text-primary-contrast dark:border-white/20 dark:bg-white/10 dark:backdrop-blur-xs',
+        'dark:focus:border-primary-light/70 dark:focus:ring-primary-light/30',
+      ]}
+    >
+      <option value="system">System</option>
+      <option value="light">Light</option>
+      <option value="dark">Dark</option>
+    </select>
+    <Icon
+      name="mdi:chevron-down"
+      class:list={[
+        'pointer-events-none absolute top-1/2 right-3 z-10 h-5 w-5 -translate-y-1/2',
+        'text-stone-500 dark:text-white/70',
+      ]}
+    />
+  </div>
+</theme-switcher>
+
+<script>
+  type ThemeOption = 'light' | 'dark' | 'system'
+
+  class ThemeSwitcher extends HTMLElement {
+    select: HTMLSelectElement | null = null
+    themeIcons: Element[] = []
+    mediaQuery: MediaQueryList
+    onChangeHandler: (event: Event) => void
+    onSystemThemeChangeHandler: () => void
+
+    constructor() {
+      super()
+      this.mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+      this.onChangeHandler = this.onChange.bind(this)
+      this.onSystemThemeChangeHandler = this.onSystemThemeChange.bind(this)
+    }
+
+    connectedCallback() {
+      this.select = this.querySelector<HTMLSelectElement>('select[data-theme-select]')
+      this.themeIcons = Array.from(this.querySelectorAll('[data-theme-icon]'))
+      if (this.select) {
+        this.select.addEventListener('change', this.onChangeHandler)
+      }
+
+      this.mediaQuery.addEventListener('change', this.onSystemThemeChangeHandler)
+      this.syncUi(this.getSelectedTheme())
+      this.applyTheme(this.getSelectedTheme())
+    }
+
+    disconnectedCallback() {
+      if (this.select) {
+        this.select.removeEventListener('change', this.onChangeHandler)
+      }
+
+      this.mediaQuery.removeEventListener('change', this.onSystemThemeChangeHandler)
+    }
+
+    getSelectedTheme(): ThemeOption {
+      const stored = localStorage.getItem('theme')
+      if (stored === 'light' || stored === 'dark') {
+        return stored
+      }
+
+      return 'system'
+    }
+
+    onChange(event: Event) {
+      const selected = (event.currentTarget as HTMLSelectElement).value as ThemeOption
+      if (!['system', 'light', 'dark'].includes(selected)) {
+        return
+      }
+
+      if (selected === 'system') {
+        localStorage.removeItem('theme')
+      } else {
+        localStorage.setItem('theme', selected)
+      }
+
+      this.applyTheme(selected)
+      this.syncUi(selected)
+    }
+
+    onSystemThemeChange() {
+      if (this.getSelectedTheme() === 'system') {
+        this.applyTheme('system')
+      }
+    }
+
+    applyTheme(theme: ThemeOption) {
+      const useDark = theme === 'dark' || (theme === 'system' && this.mediaQuery.matches)
+
+      document.documentElement.classList.toggle('dark', useDark)
+    }
+
+    syncUi(theme: ThemeOption) {
+      if (this.select) {
+        this.select.value = theme
+      }
+
+      for (const icon of this.themeIcons) {
+        const iconTheme = icon.getAttribute('data-theme-icon')
+        icon.classList.toggle('hidden', iconTheme !== theme)
+      }
+    }
+  }
+
+  if (!customElements.get('theme-switcher')) {
+    customElements.define('theme-switcher', ThemeSwitcher)
+  }
+</script>

--- a/src/components/ThemeSwitcher.astro
+++ b/src/components/ThemeSwitcher.astro
@@ -5,20 +5,16 @@ import { Icon } from 'astro-icon/components'
 <theme-switcher>
   <div class="relative">
     <div class="pointer-events-none absolute top-1/2 left-3 z-10 -translate-y-1/2">
-      <Icon
-        name="mdi:monitor"
-        data-theme-icon="system"
-        class:list={['h-5 w-5 text-stone-500 dark:text-white/70']}
-      />
+      <Icon name="mdi:monitor" data-theme-icon="system" class:list={['text-icon-muted h-5 w-5']} />
       <Icon
         name="mdi:white-balance-sunny"
         data-theme-icon="light"
-        class:list={['hidden h-5 w-5 text-stone-500 dark:text-white/70']}
+        class:list={['text-icon-muted hidden h-5 w-5']}
       />
       <Icon
         name="mdi:moon-waning-crescent"
         data-theme-icon="dark"
-        class:list={['hidden h-5 w-5 text-stone-500 dark:text-white/70']}
+        class:list={['text-icon-muted hidden h-5 w-5']}
       />
     </div>
     <select
@@ -26,10 +22,8 @@ import { Icon } from 'astro-icon/components'
       aria-label="Theme"
       class:list={[
         'appearance-none rounded-lg border px-3 py-2.5 pr-9 pl-10 text-sm shadow-inner',
-        'focus:border-stone-400 focus:ring-2 focus:ring-stone-300/70 focus:outline-hidden',
-        'text-primary-main border-stone-300 bg-white',
-        'dark:text-primary-contrast dark:border-white/20 dark:bg-white/10 dark:backdrop-blur-xs',
-        'dark:focus:border-primary-light/70 dark:focus:ring-primary-light/30',
+        'focus:border-border-main focus:ring-border-light/70 focus:ring-2 focus:outline-hidden',
+        'text-fg-light border-border-light bg-card-light backdrop-blur-xs',
       ]}
     >
       <option value="system">System</option>
@@ -40,7 +34,7 @@ import { Icon } from 'astro-icon/components'
       name="mdi:chevron-down"
       class:list={[
         'pointer-events-none absolute top-1/2 right-3 z-10 h-5 w-5 -translate-y-1/2',
-        'text-stone-500 dark:text-white/70',
+        'text-icon-muted',
       ]}
     />
   </div>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -78,7 +78,7 @@ gtag('config', ${JSON.stringify(analyticsId)});`}
       ) : null
     }
   </head>
-  <body class="dark:bg-primary-dark bg-white text-stone-900 dark:text-stone-100">
+  <body class="bg-primary-contrast text-fg-light dark:bg-primary-dark dark:text-fg-light">
     <PageHeader site={site} class:list={['mb-8']} />
     <main class:list={['container mx-auto px-4 xl:max-w-(--breakpoint-xl)']}>
       <slot />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -21,7 +21,7 @@ const analyticsId = DEPLOY_CONTEXT === 'production' ? ANALYTICS_TRACKING_ID : ''
 ---
 
 <!doctype html>
-<html lang={'en'}>
+<html lang={'en'} class="scheme-light dark:scheme-dark">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
@@ -49,6 +49,15 @@ const analyticsId = DEPLOY_CONTEXT === 'production' ? ANALYTICS_TRACKING_ID : ''
       ))
     }
     <meta name="generator" content={Astro.generator} />
+    <script
+      is:inline
+      set:html={`(() => {
+  const persistedTheme = localStorage.getItem('theme')
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+  const useDark = persistedTheme === 'dark' || (!persistedTheme && prefersDark)
+  document.documentElement.classList.toggle('dark', useDark)
+})()`}
+    />
     <slot name="seo" />
     {
       analyticsId ? (
@@ -69,7 +78,7 @@ gtag('config', ${JSON.stringify(analyticsId)});`}
       ) : null
     }
   </head>
-  <body>
+  <body class="dark:bg-primary-dark bg-white text-stone-900 dark:text-stone-100">
     <PageHeader site={site} class:list={['mb-8']} />
     <main class:list={['container mx-auto px-4 xl:max-w-(--breakpoint-xl)']}>
       <slot />

--- a/src/pages/article/[id].astro
+++ b/src/pages/article/[id].astro
@@ -86,7 +86,13 @@ const { Content, remarkPluginFrontmatter: frontmatter } = await render(article)
     <ArticleImage featured={data.featured} class:list={['mt-4']} />
     {data.enhanced && <LLMDisclaimer class:list={['mt-4']} />}
     <div class:list={['mt-4 grid grid-cols-6 gap-x-4']}>
-      <div class:list={['prose col-span-6 max-w-none', 'md:prose-lg lg:prose-xl lg:col-span-4']}>
+      <div
+        class:list={[
+          'prose prose-a:text-primary-main col-span-6 max-w-none',
+          'dark:prose-invert dark:prose-a:text-secondary-main',
+          'md:prose-lg lg:prose-xl lg:col-span-4',
+        ]}
+      >
         <Content components={{ a: LinkMDX, Alert: Alert }} />
       </div>
       <div class:list={['hidden lg:col-span-2 lg:block']}>

--- a/src/pages/article/[id].astro
+++ b/src/pages/article/[id].astro
@@ -88,8 +88,8 @@ const { Content, remarkPluginFrontmatter: frontmatter } = await render(article)
     <div class:list={['mt-4 grid grid-cols-6 gap-x-4']}>
       <div
         class:list={[
-          'prose prose-a:text-primary-main col-span-6 max-w-none',
-          'dark:prose-invert dark:prose-a:text-secondary-main',
+          'prose prose-a:text-link-light col-span-6 max-w-none',
+          'dark:prose-invert dark:prose-a:text-link-main',
           'md:prose-lg lg:prose-xl lg:col-span-4',
         ]}
       >

--- a/src/pages/author/[id].astro
+++ b/src/pages/author/[id].astro
@@ -85,10 +85,10 @@ const { articles, total } = await getArticlesByAuthor(author.id, limit)
       />
     </div>
     <hgroup class:list={['flex flex-col']}>
-      <h3 class:list={['text-3xl leading-snug text-stone-900 dark:text-stone-100', 'md:text-5xl']}>
+      <h3 class:list={['text-fg-light text-3xl leading-snug', 'md:text-5xl']}>
         {data.name}
       </h3>
-      <h4 class:list={['text-sm text-stone-600 dark:text-stone-300']}>
+      <h4 class:list={['text-fg-main text-sm']}>
         {author.data.tagline}
       </h4>
       <p class:list={['text-md grow leading-tight', 'xl:text-lg']}>{data.bio}</p>

--- a/src/pages/author/[id].astro
+++ b/src/pages/author/[id].astro
@@ -85,8 +85,10 @@ const { articles, total } = await getArticlesByAuthor(author.id, limit)
       />
     </div>
     <hgroup class:list={['flex flex-col']}>
-      <h3 class:list={['text-3xl leading-snug text-stone-900', 'md:text-5xl']}>{data.name}</h3>
-      <h4 class:list={['text-sm text-stone-600']}>
+      <h3 class:list={['text-3xl leading-snug text-stone-900 dark:text-stone-100', 'md:text-5xl']}>
+        {data.name}
+      </h3>
+      <h4 class:list={['text-sm text-stone-600 dark:text-stone-300']}>
         {author.data.tagline}
       </h4>
       <p class:list={['text-md grow leading-tight', 'xl:text-lg']}>{data.bio}</p>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -19,9 +19,9 @@
   --color-card-dark: rgb(231, 229, 228);
   --color-card-contrast: rgb(55, 71, 79);
 
-  --color-border-light: rgb(214, 211, 209);
-  --color-border-main: rgb(120, 113, 108);
-  --color-border-contrast: rgb(98, 114, 123);
+  --color-stroke-light: rgb(214, 211, 209);
+  --color-stroke-main: rgb(120, 113, 108);
+  --color-stroke-contrast: rgb(98, 114, 123);
 
   --color-fg-light: rgb(28, 25, 23);
   --color-fg-main: rgb(87, 83, 78);
@@ -80,8 +80,8 @@
     --color-card-main: rgb(55, 71, 79, 0.55);
     --color-card-dark: rgb(55, 71, 79, 0.7);
 
-    --color-border-light: rgb(98, 114, 123, 0.35);
-    --color-border-main: rgb(98, 114, 123, 0.7);
+    --color-stroke-light: rgb(98, 114, 123, 0.35);
+    --color-stroke-main: rgb(98, 114, 123, 0.7);
 
     --color-fg-light: rgb(245, 245, 244);
     --color-fg-main: rgb(214, 211, 209);

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -14,6 +14,31 @@
   --color-secondary-dark: rgb(90, 146, 22);
   --color-secondary-contrast: rgb(46, 46, 46);
 
+  --color-card-light: rgb(255, 255, 255);
+  --color-card-main: rgb(245, 245, 244);
+  --color-card-dark: rgb(231, 229, 228);
+  --color-card-contrast: rgb(55, 71, 79);
+
+  --color-border-light: rgb(214, 211, 209);
+  --color-border-main: rgb(120, 113, 108);
+  --color-border-contrast: rgb(98, 114, 123);
+
+  --color-fg-light: rgb(28, 25, 23);
+  --color-fg-main: rgb(87, 83, 78);
+  --color-fg-dark: rgb(68, 64, 60);
+  --color-fg-contrast: rgb(245, 245, 244);
+  --color-fg-contrast-muted: rgb(214, 211, 209);
+
+  --color-link-light: rgb(55, 71, 79);
+  --color-link-main: rgb(90, 146, 22);
+  --color-link-dark: rgb(90, 146, 22);
+  --color-link-contrast: rgb(139, 195, 74);
+
+  --color-icon-main: rgb(55, 71, 79);
+  --color-icon-muted: rgb(120, 113, 108);
+  --color-icon-contrast: rgb(255, 255, 255);
+  --color-icon-contrast-muted: rgb(255, 255, 255, 0.7);
+
   --breakpoint-xs: 420px;
 
   --aspect-ultrawide: 21 / 9;
@@ -48,6 +73,26 @@
   ::backdrop,
   ::file-selector-button {
     border-color: var(--color-gray-200, currentColor);
+  }
+
+  .dark {
+    --color-card-light: rgb(55, 71, 79, 0.35);
+    --color-card-main: rgb(55, 71, 79, 0.55);
+    --color-card-dark: rgb(55, 71, 79, 0.7);
+
+    --color-border-light: rgb(98, 114, 123, 0.35);
+    --color-border-main: rgb(98, 114, 123, 0.7);
+
+    --color-fg-light: rgb(245, 245, 244);
+    --color-fg-main: rgb(214, 211, 209);
+    --color-fg-dark: rgb(231, 229, 228);
+
+    --color-link-light: rgb(190, 246, 122);
+    --color-link-main: rgb(139, 195, 74);
+    --color-link-dark: rgb(190, 246, 122);
+
+    --color-icon-main: rgb(255, 255, 255);
+    --color-icon-muted: rgb(255, 255, 255, 0.7);
   }
 }
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,4 +1,5 @@
 @import 'tailwindcss';
+@custom-variant dark (&:where(.dark, .dark *));
 
 @plugin '@tailwindcss/typography';
 

--- a/test/components/ArticleCardLead.test.ts
+++ b/test/components/ArticleCardLead.test.ts
@@ -52,10 +52,10 @@ describe('articleCardLead', () => {
     const html = await renderCard()
 
     expect(html).toContain('fetchpriority="high"')
-    expect(html).toContain('w-full bg-white')
-    expect(html).toContain('text-lg leading-snug font-medium text-stone-900')
-    expect(html).toContain('text-sm text-stone-600')
-    expect(html).toContain('text-md mt-2 leading-relaxed text-stone-700')
+    expect(html).toContain('bg-card-light w-full')
+    expect(html).toContain('text-fg-light')
+    expect(html).toContain('text-fg-main')
+    expect(html).toContain('text-fg-dark')
   })
 
   test('keeps overlay treatment for large screens', async () => {

--- a/test/components/PageFooter.test.ts
+++ b/test/components/PageFooter.test.ts
@@ -26,7 +26,7 @@ describe('pageFooter', () => {
     expect(html).toContain(`title="${site.data.title} - RSS"`)
     expect(html).toContain(`title="${site.data.title} - Repository"`)
     expect(html).toContain('class="block rounded-full p-2')
-    expect(html).toContain('dark:hover:bg-primary-main/70 dark:focus:bg-primary-main')
+    expect(html).toContain('hover:bg-card-main focus:bg-card-dark')
     expect(html).toContain('mdi:rss-feed')
     expect(html).toContain('mdi:github')
   })

--- a/test/components/PageFooter.test.ts
+++ b/test/components/PageFooter.test.ts
@@ -1,5 +1,52 @@
-import { describe, test } from 'vitest'
+import PageFooter from '@components/PageFooter.astro'
+import { getDefaultSite } from '@utils/site'
+import { experimental_AstroContainer as AstroContainer } from 'astro/container'
+import type { CollectionEntry } from 'astro:content'
+import { beforeAll, describe, expect, test } from 'vitest'
 
 describe('pageFooter', () => {
-  test.todo('implement tests for this component')
+  let site: CollectionEntry<'site'>
+
+  beforeAll(async () => {
+    site = await getDefaultSite()
+  })
+
+  const render = async (className?: string) => {
+    const container = await AstroContainer.create()
+    return await container.renderToString(PageFooter, {
+      props: { site, class: className },
+    })
+  }
+
+  test('renders footer action buttons', async () => {
+    const html = await render()
+
+    expect(html).toContain('href="/rss.xml"')
+    expect(html).toContain(`href="${site.data.repository}"`)
+    expect(html).toContain(`title="${site.data.title} - RSS"`)
+    expect(html).toContain(`title="${site.data.title} - Repository"`)
+    expect(html).toContain('class="block rounded-full p-2')
+    expect(html).toContain('dark:hover:bg-primary-main/70 dark:focus:bg-primary-main')
+    expect(html).toContain('mdi:rss-feed')
+    expect(html).toContain('mdi:github')
+  })
+
+  test('renders theme switcher in footer', async () => {
+    const html = await render()
+
+    expect(html).toContain('<theme-switcher')
+  })
+
+  test('renders copyright text with current year and site title', async () => {
+    const html = await render()
+    const year = new Date().getFullYear()
+
+    expect(html).toContain(`text-center text-xs`)
+    expect(html).toContain(`${year} ${site.data.title}`)
+  })
+
+  test('adds custom classes when provided', async () => {
+    const html = await render('test-class')
+    expect(html).toContain('test-class')
+  })
 })

--- a/test/components/SocialBar.test.ts
+++ b/test/components/SocialBar.test.ts
@@ -47,9 +47,7 @@ describe('socialBar', () => {
 
   test('that it contains an icon for each social', async () => {
     socials.forEach((social) => {
-      expect(socialBar).toContain(
-        `<svg width="1em" height="1em" class="text-primary-main h-6 w-6" data-icon="mdi:${social.name.toLowerCase()}"`
-      )
+      expect(socialBar).toContain(`data-icon="mdi:${social.name.toLowerCase()}"`)
     })
   })
 

--- a/test/components/ThemeSwitcher.test.ts
+++ b/test/components/ThemeSwitcher.test.ts
@@ -1,0 +1,36 @@
+import ThemeSwitcher from '@components/ThemeSwitcher.astro'
+import { experimental_AstroContainer as AstroContainer } from 'astro/container'
+import { describe, expect, test } from 'vitest'
+
+describe('themeSwitcher', () => {
+  const render = async () => {
+    const container = await AstroContainer.create()
+    return await container.renderToString(ThemeSwitcher)
+  }
+
+  test('renders a dropdown with system, light, and dark options', async () => {
+    const html = await render()
+
+    expect(html).toContain('<theme-switcher')
+    expect(html).toContain('data-theme-select')
+    expect(html).toContain('aria-label="Theme"')
+    expect(html).toContain('option value="system"')
+    expect(html).toContain('option value="light"')
+    expect(html).toContain('option value="dark"')
+    expect(html).toContain('>System</option>')
+    expect(html).toContain('>Light</option>')
+    expect(html).toContain('>Dark</option>')
+  })
+
+  test('renders state icons and dropdown chevron', async () => {
+    const html = await render()
+
+    expect(html).toContain('data-theme-icon="system"')
+    expect(html).toContain('data-theme-icon="light"')
+    expect(html).toContain('data-theme-icon="dark"')
+    expect(html).toContain('mdi:monitor')
+    expect(html).toContain('mdi:white-balance-sunny')
+    expect(html).toContain('mdi:moon-waning-crescent')
+    expect(html).toContain('mdi:chevron-down')
+  })
+})

--- a/test/layouts/Layout.test.ts
+++ b/test/layouts/Layout.test.ts
@@ -52,7 +52,7 @@ describe('layout', () => {
   test('renders the layout shell and named slots', async () => {
     const html = await render()
 
-    expect(html).toContain('<html lang="en">')
+    expect(html).toContain('<html lang="en" class="scheme-light dark:scheme-dark">')
     expect(html).toContain(`<meta name="theme-color" content="${site.data.theme}">`)
     expect(html).toContain('<link rel="manifest" href="/site.webmanifest">')
     expect(html).toContain('<link rel="sitemap" href="/sitemap-index.xml">')


### PR DESCRIPTION
## Summary

Adds site-wide dark mode support with a persistent theme switcher, improves dark-mode contrast across key pages/components, and refactors the switcher into a dedicated component with focused tests. Also includes a minor release bump.

## Linked issue

Closes #70

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Maintenance / cleanup
- [ ] Documentation / content
- [ ] Breaking change

## Details

- Added class-based dark mode setup and initial theme hydration to avoid theme flash.
- Added persistent footer theme switcher (system/light/dark), then extracted it into `ThemeSwitcher.astro`.
- Improved dark-mode contrast for article content, cards, breadcrumbs, author page surfaces, footer/social controls, and related tests.
- Reduced brittleness in icon-based tests where appropriate.

## Release / deploy impact

- [x] Preview deploy is useful for reviewing this change
- [ ] Safe to label `no-deploy`
- [x] This PR intentionally updates the version in `package.json`

## Validation

- [x] Lint passes locally
- [x] Unit tests pass locally
- [x] Added or updated tests where appropriate
- [x] Manually verified changes
- [ ] Documentation updated where appropriate

## Reviewer notes

Version updated from `6.4.0` to `6.5.0` as a minor release for the new feature set.
