### PR TITLE
perf(home): preload QuoteCardLead chalkboard background image

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agingdeveloper",
   "private": true,
   "description": "The personal site of Richard Klein",
-  "version": "6.6.0",
+  "version": "6.6.1",
   "type": "module",
   "packageManager": "pnpm@10.24.0",
   "scripts": {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -58,6 +58,7 @@ const analyticsId = DEPLOY_CONTEXT === 'production' ? ANALYTICS_TRACKING_ID : ''
   document.documentElement.classList.toggle('dark', useDark)
 })()`}
     />
+    <slot name="preload" />
     <slot name="seo" />
     {
       analyticsId ? (

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -28,7 +28,7 @@ const latest = await getLatestQuote()
 ---
 
 <Layout site={site}>
-  <link rel="preload" as="image" href={chalkboard.src} slot="preload" />
+  <link rel="preload" as="image" href={chalkboard.src} fetchpriority="high" slot="preload" />
   <Fragment slot="seo">
     <SeoBasic title={data.title} description={data.tagline} site={site} />
     <OpenGraphCore site={site} title={data.title} description={data.tagline} type="website" />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -17,6 +17,8 @@ import { getArticles } from '@utils/article'
 import { getLatestQuote } from '@utils/quote'
 import { getDefaultSite } from '@utils/site'
 
+import chalkboard from '../content/image/chalkboard.jpg'
+
 // get the articles and sort them in decending published date
 const articles = await getArticles(9)
 const site = await getDefaultSite()
@@ -26,6 +28,7 @@ const latest = await getLatestQuote()
 ---
 
 <Layout site={site}>
+  <link rel="preload" as="image" href={chalkboard.src} slot="preload" />
   <Fragment slot="seo">
     <SeoBasic title={data.title} description={data.tagline} site={site} />
     <OpenGraphCore site={site} title={data.title} description={data.tagline} type="website" />

--- a/test/layouts/Layout.test.ts
+++ b/test/layouts/Layout.test.ts
@@ -7,6 +7,7 @@ describe('layout', () => {
   type RenderOptions = {
     deployContext?: string
     analyticsTrackingId?: string
+    preloadSlot?: string
     seoSlot?: string
     defaultSlot?: string
   }
@@ -26,6 +27,7 @@ describe('layout', () => {
   const render = async ({
     deployContext = 'dev',
     analyticsTrackingId = '',
+    preloadSlot,
     seoSlot = '<meta name="description" content="SEO slot description" />',
     defaultSlot = '<p>Layout body content</p>',
   }: RenderOptions = {}) => {
@@ -43,6 +45,7 @@ describe('layout', () => {
     return await container.renderToString(Layout, {
       props: { site },
       slots: {
+        ...(preloadSlot ? { preload: preloadSlot } : {}),
         seo: seoSlot,
         default: defaultSlot,
       },
@@ -60,9 +63,18 @@ describe('layout', () => {
     expect(html).toContain('href="http://localhost:4321/rss.xml"')
     expect(html).toContain('href="http://localhost:4321/atom.xml"')
     expect(html).toContain('href="http://localhost:4321/feed.json"')
+    expect(html).not.toContain('href="/_astro/chalkboard.jpg"')
     expect(html).toContain('<meta name="description" content="SEO slot description" />')
     expect(html).toContain('<main class="container mx-auto px-4 xl:max-w-(--breakpoint-xl)"')
     expect(html).toContain('<p>Layout body content</p>')
+  })
+
+  test('renders preload slot content in head when provided', async () => {
+    const html = await render({
+      preloadSlot: '<link rel="preload" as="image" href="/_astro/chalkboard.jpg" />',
+    })
+
+    expect(html).toContain('<link rel="preload" as="image" href="/_astro/chalkboard.jpg" />')
   })
 
   test('does not inject analytics when deploy context is not production', async () => {


### PR DESCRIPTION
## Summary

Preload the QuoteCardLead chalkboard background image from the home page so the request is discovered in `<head>` instead of late from CSS background parsing.

## Linked issue

Closes #881

## Type of change

_Put an `x` in the boxes that apply._

- [ ] Bug fix
- [ ] Feature
- [x] Maintenance / cleanup
- [ ] Documentation / content
- [ ] Breaking change

## Details

- Added a dedicated `<slot name="preload" />` in `Layout` head.
- Registered a home-page-only preload link in `src/pages/index.astro` for the chalkboard image used by `QuoteCardLead`.
- Updated layout tests to verify preload slot behavior when provided and when omitted.
- Bumped package version from `6.6.0` to `6.6.1` for a patch release.

## Release / deploy impact

_Put an `x` in the boxes that apply._

- [x] Preview deploy is useful for reviewing this change
- [ ] Safe to label `no-deploy`
- [x] This PR intentionally updates the version in `package.json`

## Validation

_Put an `x` in the boxes that apply._

- [x] Lint passes locally
- [x] Unit tests pass locally
- [x] Added or updated tests where appropriate
- [x] Manually verified changes
- [ ] Documentation updated where appropriate

## Reviewer notes

Validation run locally:
- `pnpm run lint:fix`
- `pnpm run format:fix`
- `pnpm run verify`

Commits:
1. `perf(home): preload quote card background image`
2. `chore(release): bump version to 6.6.1`