### PR TITLE
ci(lighthouse): run mobile and desktop profiles with summary output

### DIFF
--- a/.github/workflows/code-lighthouse.yaml
+++ b/.github/workflows/code-lighthouse.yaml
@@ -10,7 +10,8 @@ on:
       pr-number:
         description: 'Pull request number to comment on'
         type: string
-        required: true
+        required: false
+        default: ''
       checkout-ref:
         description: 'Git ref or SHA that was deployed'
         required: false
@@ -24,14 +25,21 @@ on:
 
 jobs:
   lighthouse:
-    name: 'Lighthouse'
+    name: Lighthouse (${{ matrix.profile }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        profile:
+          - mobile
+          - desktop
     permissions:
       contents: read
       pull-requests: write
     env:
       LIGHTHOUSE_BASE_URL: ${{ inputs.base-url }}
       LIGHTHOUSE_NUMBER_OF_RUNS: ${{ inputs.number-of-runs }}
+      LIGHTHOUSE_FORM_FACTOR: ${{ matrix.profile }}
 
     steps:
       - name: 'Checkout source code'
@@ -46,6 +54,7 @@ jobs:
         env:
           LIGHTHOUSE_BASE_URL: ${{ inputs.base-url }}
           LIGHTHOUSE_NUMBER_OF_RUNS: ${{ inputs.number-of-runs }}
+          LIGHTHOUSE_FORM_FACTOR: ${{ matrix.profile }}
         run: |
           pnpm exec lhci collect --config=.lighthouserc.cjs
 
@@ -55,46 +64,64 @@ jobs:
 
       - name: 'Upload public reports'
         run: |
-          pnpm exec lhci upload --config=.lighthouserc.cjs --target=temporary-public-storage | tee ./lhci-public.txt
+          pnpm exec lhci upload --config=.lighthouserc.cjs --target=temporary-public-storage | tee ./lhci-public-${{ matrix.profile }}.txt
 
       - name: 'Upload filesystem reports'
         run: |
-          rm -rf ./lhci
-          mkdir -p ./lhci
-          pnpm exec lhci upload --config=.lighthouserc.cjs --target=filesystem --outputDir=./lhci
+          rm -rf ./lhci-${{ matrix.profile }}
+          mkdir -p ./lhci-${{ matrix.profile }}
+          pnpm exec lhci upload --config=.lighthouserc.cjs --target=filesystem --outputDir=./lhci-${{ matrix.profile }}
 
       - name: 'Upload Lighthouse artifact'
         uses: actions/upload-artifact@v7
         with:
-          name: lighthouse-results-pr-${{ inputs.pr-number }}
-          path: ./lhci
+          name: lighthouse-results-${{ inputs.pr-number != '' && format('pr-{0}', inputs.pr-number) || format('run-{0}', github.run_id) }}-${{ matrix.profile }}
+          path: ./lhci-${{ matrix.profile }}
           retention-days: 7
 
-      - name: 'Build Lighthouse comment'
+      - name: 'Build Lighthouse report'
         env:
           LIGHTHOUSE_BASE_URL: ${{ inputs.base-url }}
           LIGHTHOUSE_NUMBER_OF_RUNS: ${{ inputs.number-of-runs }}
+          LIGHTHOUSE_FORM_FACTOR: ${{ matrix.profile }}
           COMMIT_SHA: ${{ inputs.checkout-ref }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_SERVER_URL: ${{ github.server_url }}
         run: |
-          LIGHTHOUSE_COMMENT="$(node ./scripts/lighthouse-report-builder.mjs ./lhci/manifest.json ./lhci-public.txt)"
-          echo "LIGHTHOUSE_COMMENT<<EOF" >> "$GITHUB_ENV"
-          echo "$LIGHTHOUSE_COMMENT" >> "$GITHUB_ENV"
+          LIGHTHOUSE_REPORT="$(node ./scripts/lighthouse-report-builder.mjs ./lhci-${{ matrix.profile }}/manifest.json ./lhci-public-${{ matrix.profile }}.txt)"
+          echo "LIGHTHOUSE_REPORT<<EOF" >> "$GITHUB_ENV"
+          echo "$LIGHTHOUSE_REPORT" >> "$GITHUB_ENV"
           echo "EOF" >> "$GITHUB_ENV"
 
+      - name: 'Write Lighthouse summary'
+        run: |
+          {
+            echo "## Lighthouse Report (${{ matrix.profile }})"
+            echo
+            echo "- Preview: ${{ inputs.base-url }}"
+            echo "- Commit: ${{ inputs.checkout-ref }}"
+            echo "- Runs per URL: ${{ inputs.number-of-runs }}"
+            echo "- Profile: ${{ matrix.profile }}"
+            echo "- Artifact: lighthouse-results-${{ inputs.pr-number != '' && format('pr-{0}', inputs.pr-number) || format('run-{0}', github.run_id) }}-${{ matrix.profile }}"
+            echo
+            echo "${{ env.LIGHTHOUSE_REPORT }}"
+            echo
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: 'Comment results on pull reuqest'
+        if: inputs.pr-number != ''
         uses: marocchino/sticky-pull-request-comment@v3
         with:
-          header: lighthouse-report
+          header: lighthouse-report-${{ matrix.profile }}
           message: |
-            ## Lighthouse Report
+            ## Lighthouse Report (${{ matrix.profile }})
 
             - Preview: ${{ inputs.base-url }}
             - Commit: ${{ inputs.checkout-ref }}
             - Runs per URL: ${{ inputs.number-of-runs }}
+            - Profile: ${{ matrix.profile }}
 
-            ${{ env.LIGHTHOUSE_COMMENT }}
+            ${{ env.LIGHTHOUSE_REPORT }}
 
             You can also download the report as an artifact from the [workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).

--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -119,11 +119,9 @@ jobs:
     needs: publish-release
     permissions:
       contents: read
-      pull-requests: write
     if: needs.publish-release.result == 'success'
     uses: ./.github/workflows/code-lighthouse.yaml
     with:
       base-url: ${{ needs.publish-release.outputs.deploy_url }}
-      pr-number: ${{ github.event.pull_request.number }}
-      checkout-ref: ${{ github.event.pull_request.head.sha }}
+      checkout-ref: ${{ github.sha }}
       number-of-runs: 3

--- a/.lighthouserc.cjs
+++ b/.lighthouserc.cjs
@@ -9,6 +9,7 @@ const auditedPaths = [
 ]
 const baseUrl = (process.env.LIGHTHOUSE_BASE_URL || '').replace(/\/$/, '')
 const numberOfRuns = Number.parseInt(process.env.LIGHTHOUSE_NUMBER_OF_RUNS || '1', 10)
+const formFactor = (process.env.LIGHTHOUSE_FORM_FACTOR || 'mobile').toLowerCase()
 
 if (!baseUrl) {
   throw new Error('LIGHTHOUSE_BASE_URL is required for Lighthouse CI runs')
@@ -18,14 +19,25 @@ if (!Number.isInteger(numberOfRuns) || numberOfRuns < 1) {
   throw new Error('LIGHTHOUSE_NUMBER_OF_RUNS must be an integer greater than 0')
 }
 
+if (!['mobile', 'desktop'].includes(formFactor)) {
+  throw new Error('LIGHTHOUSE_FORM_FACTOR must be either "mobile" or "desktop"')
+}
+
+const collectSettings = {
+  chromeFlags: '--headless=new --no-sandbox',
+  formFactor,
+}
+
+if (formFactor === 'desktop') {
+  collectSettings.preset = 'desktop'
+}
+
 module.exports = {
   ci: {
     collect: {
       numberOfRuns,
       url: auditedPaths.map((currentPath) => `${baseUrl}${currentPath}`),
-      settings: {
-        chromeFlags: '--headless=new --no-sandbox',
-      },
+      settings: collectSettings,
     },
     assert: {
       assertions: {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agingdeveloper",
   "private": true,
   "description": "The personal site of Richard Klein",
-  "version": "6.6.1",
+  "version": "6.6.2",
   "type": "module",
   "packageManager": "pnpm@10.24.0",
   "scripts": {


### PR DESCRIPTION
## Summary

Run Lighthouse CI for both mobile and desktop profiles and publish profile-specific results to the workflow step summary for preview deploy and tag-release runs.

## Linked issue

Closes #873

## Type of change

_Put an `x` in the boxes that apply._

- [ ] Bug fix
- [ ] Feature
- [x] Maintenance / cleanup
- [ ] Documentation / content
- [ ] Breaking change

## Details

- Updated `.github/workflows/code-lighthouse.yaml` to run a `mobile`/`desktop` matrix.
- Added profile-specific artifact names and sticky comment headers so results do not overwrite each other.
- Added step summary output (`$GITHUB_STEP_SUMMARY`) per profile, including run metadata and report tables/links.
- Made `pr-number` optional and gated PR comments so they only post when a PR number is provided.
- Updated `.lighthouserc.cjs` to consume `LIGHTHOUSE_FORM_FACTOR` and apply desktop preset settings when applicable.
- Updated `.github/workflows/tag-release.yaml` to pass release commit context (`github.sha`) into the reusable Lighthouse workflow.

## Release / deploy impact

_Put an `x` in the boxes that apply._

- [x] Preview deploy is useful for reviewing this change
- [ ] Safe to label `no-deploy`
- [x] This PR intentionally updates the version in `package.json`

## Validation

_Put an `x` in the boxes that apply._

- [x] Lint passes locally
- [x] Unit tests pass locally
- [ ] Added or updated tests where appropriate
- [x] Manually verified changes
- [ ] Documentation updated where appropriate

## Reviewer notes

`pnpm run lint:fix`, `pnpm run format:fix`, and `pnpm run verify` all passed locally.