### PR TITLE
ci(lighthouse): inherit reusable workflow permissions and bump release

### DIFF
--- a/.github/workflows/code-lighthouse.yaml
+++ b/.github/workflows/code-lighthouse.yaml
@@ -33,9 +33,6 @@ jobs:
         profile:
           - mobile
           - desktop
-    permissions:
-      contents: read
-      pull-requests: write
     env:
       LIGHTHOUSE_BASE_URL: ${{ inputs.base-url }}
       LIGHTHOUSE_NUMBER_OF_RUNS: ${{ inputs.number-of-runs }}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agingdeveloper",
   "private": true,
   "description": "The personal site of Richard Klein",
-  "version": "6.6.2",
+  "version": "6.6.3",
   "type": "module",
   "packageManager": "pnpm@10.24.0",
   "scripts": {


### PR DESCRIPTION
## Summary

Fix reusable Lighthouse workflow permissions so tag-release can call it without requesting pull request write access, and bump the package version to trigger a new release pipeline run.

## Linked issue

Closes #873

## Type of change

_Put an `x` in the boxes that apply._

- [x] Bug fix
- [ ] Feature
- [x] Maintenance / cleanup
- [ ] Documentation / content
- [ ] Breaking change

## Details

- Removed explicit job-level `permissions` from `.github/workflows/code-lighthouse.yaml` so reusable workflow permissions inherit from the caller job.
- This avoids validation failure in `tag-release` where `pull-requests: write` is not granted.
- Bumped `package.json` version from `6.6.2` to `6.6.3` to ensure the release/tag workflow executes all jobs with the fix.

## Release / deploy impact

_Put an `x` in the boxes that apply._

- [x] Preview deploy is useful for reviewing this change
- [ ] Safe to label `no-deploy`
- [x] This PR intentionally updates the version in `package.json`

## Validation

_Put an `x` in the boxes that apply._

- [ ] Lint passes locally
- [ ] Unit tests pass locally
- [ ] Added or updated tests where appropriate
- [x] Manually verified changes
- [ ] Documentation updated where appropriate

## Reviewer notes

This is a follow-up hotfix after merging PR #885; it resolves the reusable-workflow permission mismatch surfaced by GitHub workflow validation.