### PR TITLE
content(quote): add weekly quote for May 5, 2026

### DIFF
--- a/.claude/commands/weekly-quote.md
+++ b/.claude/commands/weekly-quote.md
@@ -10,16 +10,18 @@ $ARGUMENTS
 
 ## Step 1 — Find a quote
 
-Read `src/content/data/quote.json` to understand the existing quote style and to avoid suggesting duplicates.
+Read `src/content/data/quote.json` to understand the existing quote style and to check for duplicates.
 
-Then search the web for quotes that fit the theme above. Suggest **3–5 candidates**, each on its own numbered line in this format:
+Then search the web for quotes that fit the theme above. Prefer **shorter quotes** that are easy to write on a chalkboard. Favor quotes with verifiable citation sources, though a source is not required.
+
+Suggest **3–5 candidates** that have not already appeared in `quote.json`, each on its own numbered line in this format:
 
 ```
 1. "Quote text" — Author (Source title, year) [if known]
 2. ...
 ```
 
-Ask the user to pick a number, paste their own quote, or request more options before continuing.
+Ask the user to pick a number, paste their own quote, or request more options. If no quote is selected, restart this step with fresh candidates.
 
 ## Step 2 — Collect details
 
@@ -27,7 +29,7 @@ Once a quote is chosen, confirm with the user:
 
 - **text** — exact quote text
 - **author** — full name (use `"Unknown"` if truly anonymous)
-- **source** (optional) — title, type (`book` | `movie` | `play` | `speech` | `letter` | `song` | `magazine` | `newspaper` | `other`), and year
+- **source** (optional) — title, type (`book` | `movie` | `show` | `play` | `speech` | `letter` | `song` | `magazine` | `newspaper` | `other`), and year
 
 Do not invent source details. If uncertain, ask or omit the source object.
 
@@ -64,7 +66,7 @@ With source:
   "chalked": "<YYYY-MM-DD>",
   "source": {
     "title": "<title>",
-    "type": "<type>",
+    "type": "<book|movie|show|play|speech|letter|song|magazine|newspaper|other>",
     "year": <year>
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agingdeveloper",
   "private": true,
   "description": "The personal site of Richard Klein",
-  "version": "6.6.6",
+  "version": "6.6.7",
   "type": "module",
   "packageManager": "pnpm@10.24.0",
   "scripts": {

--- a/src/content/data/quote.json
+++ b/src/content/data/quote.json
@@ -1,5 +1,11 @@
 [
   {
+    "id": "a3f7c2d1-84e6-4b19-9f0a-6c5d8e2b1a47",
+    "text": "My idea of housework is to sweep the room with a glance.",
+    "author": "Erma Bombeck",
+    "chalked": "2026-05-05"
+  },
+  {
     "id": "02474a76-98f1-4dea-889c-83abf1a59d71",
     "text": "A person never forgets the landscape of their childhood.",
     "author": "Kate Morton",


### PR DESCRIPTION
## Summary

Adds the weekly chalkboard quote for May 5, 2026 (Erma Bombeck) and aligns the `/weekly-quote` slash command with the chalkboard project instructions.

## Linked issue

Closes #

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Maintenance / cleanup
- [x] Documentation / content
- [ ] Breaking change

## Details

- Prepends new quote entry to `src/content/data/quote.json`:
  - *"My idea of housework is to sweep the room with a glance."* — Erma Bombeck
- Bumps `package.json` patch version `6.6.6` → `6.6.7`
- Updates `.claude/commands/weekly-quote.md` to align with the chalkboard project instructions:
  - Adds preference for shorter quotes (easy to write on a chalkboard)
  - Adds preference for verifiable citation sources
  - Adds restart-loop behavior when no quote is selected
  - Adds `show` to the source type list to match `src/content.config.ts`

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [ ] Safe to label `no-deploy`
- [x] This PR intentionally updates the version in `package.json`

## Validation

- [x] Lint passes locally
- [x] Unit tests pass locally
- [ ] Added or updated tests where appropriate
- [x] Manually verified changes
- [ ] Documentation updated where appropriate

## Reviewer notes

Source type list in the command now mirrors the `z.enum` in `src/content.config.ts` exactly.