### PR TITLE
chore: seed CHANGELOG.md and align release-please tag format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1102 @@
+# Changelog
+
+## [6.8.1](https://github.com/richwklein/agingdeveloper/compare/6.8.0...6.8.1) (2026-05-11)
+
+### Miscellaneous Changes
+
+* **quote:** add weekly quote for May 11, 2026 ([#899](https://github.com/richwklein/agingdeveloper/issues/899)) ([ca42cdc](https://github.com/richwklein/agingdeveloper/commit/ca42cdcc967976e2d28ed95ee3fd1ab0dc59cbcf))
+
+## [6.8.0](https://github.com/richwklein/agingdeveloper/compare/6.7.0...6.8.0) (2026-05-06)
+
+### Miscellaneous Changes
+
+* bump dependencies and version to 6.8.0 ([#897](https://github.com/richwklein/agingdeveloper/issues/897)) ([588b059](https://github.com/richwklein/agingdeveloper/commit/588b05942f7f3b2d6daea20fbcb4af23ec09d9bb))
+
+## [6.7.0](https://github.com/richwklein/agingdeveloper/compare/6.6.7...6.7.0) (2026-05-05)
+
+### Bug Fixes
+
+* **article-card:** equalize heights at medium breakpoint ([#890](https://github.com/richwklein/agingdeveloper/issues/890)) ([321460a](https://github.com/richwklein/agingdeveloper/commit/321460a4f051844c9d03eb3d5371e504eebfd413))
+
+## [6.6.7](https://github.com/richwklein/agingdeveloper/compare/6.6.6...6.6.7) (2026-05-05)
+
+### Miscellaneous Changes
+
+* **quote:** add weekly quote for May 5, 2026 ([#894](https://github.com/richwklein/agingdeveloper/issues/894)) ([974ebc8](https://github.com/richwklein/agingdeveloper/commit/974ebc8205378353e27cff88eb94d9c7051c66a8))
+
+## [6.6.6](https://github.com/richwklein/agingdeveloper/compare/6.6.4...6.6.6) (2026-04-27)
+
+### Miscellaneous Changes
+
+* **quote:** add weekly quote for April 27, 2026 ([#891](https://github.com/richwklein/agingdeveloper/issues/891)) ([037ea33](https://github.com/richwklein/agingdeveloper/commit/037ea3369c290ad8477d928908628f77dbd8a55c))
+
+## [6.6.4](https://github.com/richwklein/agingdeveloper/compare/6.6.3...6.6.4) (2026-04-20)
+
+### Miscellaneous Changes
+
+* **quote:** add weekly quote for April 20, 2026 ([#887](https://github.com/richwklein/agingdeveloper/issues/887)) ([aff18a9](https://github.com/richwklein/agingdeveloper/commit/aff18a934567522906413caa3aad8f213958b541))
+
+## [6.6.3](https://github.com/richwklein/agingdeveloper/compare/6.6.1...6.6.3) (2026-04-19)
+
+### Miscellaneous Changes
+
+* **lighthouse:** inherit reusable workflow permissions and bump release ([#886](https://github.com/richwklein/agingdeveloper/issues/886)) ([151dc39](https://github.com/richwklein/agingdeveloper/commit/151dc39181822ba097b37087847b7fd2d227f6d5))
+* **lighthouse:** run mobile and desktop profiles with summary output ([#885](https://github.com/richwklein/agingdeveloper/issues/885)) ([d38b32e](https://github.com/richwklein/agingdeveloper/commit/d38b32ea945f1b39c823d9a2c1f17d606df7a8ef))
+
+## [6.6.1](https://github.com/richwklein/agingdeveloper/compare/6.6.0...6.6.1) (2026-04-19)
+
+### Performance Improvements
+
+* **home:** preload QuoteCardLead chalkboard background image ([#882](https://github.com/richwklein/agingdeveloper/issues/882)) ([6e9e500](https://github.com/richwklein/agingdeveloper/commit/6e9e500de5c855f7a78140618b430cfa0dcefbd7))
+
+## [6.6.0](https://github.com/richwklein/agingdeveloper/compare/6.5.0...6.6.0) (2026-04-18)
+
+### Miscellaneous Changes
+
+* audit dependencies for static Astro build ([#880](https://github.com/richwklein/agingdeveloper/issues/880)) ([369146d](https://github.com/richwklein/agingdeveloper/commit/369146dc3a1b6ef25792e113d83ab4dc1d80ea03))
+
+## [6.5.0](https://github.com/richwklein/agingdeveloper/compare/6.4.0...6.5.0) (2026-04-18)
+
+### Features
+
+* **theme:** add dark mode support and persistent theme switcher ([#877](https://github.com/richwklein/agingdeveloper/issues/877)) ([1c9af27](https://github.com/richwklein/agingdeveloper/commit/1c9af2793513806d465bed3415ca12991b242a04))
+
+### Miscellaneous Changes
+
+* Bump sanitize-html from 2.17.2 to 2.17.3 ([#876](https://github.com/richwklein/agingdeveloper/issues/876)) ([c9373d4](https://github.com/richwklein/agingdeveloper/commit/c9373d400f9ea1f76c9f8dd2257bbae1e9f57e99))
+* fix Netlify release deploy output handling ([#875](https://github.com/richwklein/agingdeveloper/issues/875)) ([4ddb17f](https://github.com/richwklein/agingdeveloper/commit/4ddb17f2260e94d3d4eb3cf0723934a259393df6))
+
+## [6.4.0](https://github.com/richwklein/agingdeveloper/compare/6.3.1...6.4.0) (2026-04-16)
+
+### Bug Fixes
+
+* **home:** rebalance lead and quote cards on responsive layouts ([#874](https://github.com/richwklein/agingdeveloper/issues/874)) ([fc67035](https://github.com/richwklein/agingdeveloper/commit/fc670354687a0a5a7020421be2ced039525cfa94))
+
+### Miscellaneous Changes
+
+* Bump the other-dependencies group with 2 updates ([#867](https://github.com/richwklein/agingdeveloper/issues/867)) ([027fbe4](https://github.com/richwklein/agingdeveloper/commit/027fbe40ff01b98f1b2acff4853ba170e10f278a))
+* Bump the eslint group across 1 directory with 2 updates ([#871](https://github.com/richwklein/agingdeveloper/issues/871)) ([5050969](https://github.com/richwklein/agingdeveloper/commit/50509692323197ecda478aac3c26dc5e3f5681fa))
+
+## [6.3.1](https://github.com/richwklein/agingdeveloper/compare/6.2.1...6.3.1) (2026-04-16)
+
+### Features
+
+* **images:** add responsive image placeholder pipeline ([#872](https://github.com/richwklein/agingdeveloper/issues/872)) ([ffc5ad1](https://github.com/richwklein/agingdeveloper/commit/ffc5ad188d0d01622177889f0b87b80fc6e7b691))
+
+### Miscellaneous Changes
+
+* **github:** add issue forms and gate deploy previews ([#865](https://github.com/richwklein/agingdeveloper/issues/865)) ([f018835](https://github.com/richwklein/agingdeveloper/commit/f01883572c10883b88a8f684bf87c04ec8dd2dd6))
+* add Lighthouse CI checks for deployed sites ([#863](https://github.com/richwklein/agingdeveloper/issues/863)) ([81f14cd](https://github.com/richwklein/agingdeveloper/commit/81f14cd26d3ef5f3a4291333e6fb2f6a663869c1))
+
+## [6.2.1](https://github.com/richwklein/agingdeveloper/compare/6.2.0...6.2.1) (2026-04-11)
+
+### Miscellaneous Changes
+
+* [codex] move Astro fonts into the asset pipeline ([#862](https://github.com/richwklein/agingdeveloper/issues/862)) ([04fd324](https://github.com/richwklein/agingdeveloper/commit/04fd324a1725533ec61fcc60d7d9c36108b36e75))
+
+## [6.2.0](https://github.com/richwklein/agingdeveloper/compare/6.1.0...6.2.0) (2026-04-10)
+
+### Miscellaneous Changes
+
+* [codex] Add responsive header search ([#860](https://github.com/richwklein/agingdeveloper/issues/860)) ([c0ac4fe](https://github.com/richwklein/agingdeveloper/commit/c0ac4fe1abf2d69e470c4a773334ab2b1a750df7))
+
+## [6.1.0](https://github.com/richwklein/agingdeveloper/compare/6.0.0...6.1.0) (2026-04-10)
+
+### Miscellaneous Changes
+
+* [codex] Add featured images to syndicated feed items ([#858](https://github.com/richwklein/agingdeveloper/issues/858)) ([6cb4c36](https://github.com/richwklein/agingdeveloper/commit/6cb4c36cce05c0ad2ae520375ad41c234c472134))
+* Bump the eslint group across 1 directory with 4 updates ([#857](https://github.com/richwklein/agingdeveloper/issues/857)) ([ed5f710](https://github.com/richwklein/agingdeveloper/commit/ed5f710622959eb57fda0fd7b37ca38654526337))
+
+## [6.0.0](https://github.com/richwklein/agingdeveloper/compare/5.10.1...6.0.0) (2026-04-10)
+
+### Miscellaneous Changes
+
+* [codex] upgrade Astro tooling and remove standalone markdown lint workflow ([#856](https://github.com/richwklein/agingdeveloper/issues/856)) ([ee4d7bb](https://github.com/richwklein/agingdeveloper/commit/ee4d7bb9abe7a4f458224e5a80052637ab7550e1))
+
+## [5.10.1](https://github.com/richwklein/agingdeveloper/compare/5.10.0...5.10.1) (2026-04-06)
+
+### Miscellaneous Changes
+
+* cut v5.10.1 ([#854](https://github.com/richwklein/agingdeveloper/issues/854)) ([fa4218c](https://github.com/richwklein/agingdeveloper/commit/fa4218c28cb54bad301b239b9606e83ac8761ca2))
+
+## [5.10.0](https://github.com/richwklein/agingdeveloper/compare/5.9.0...5.10.0) (2026-04-05)
+
+### Miscellaneous Changes
+
+* Integrate fuse directly ([#853](https://github.com/richwklein/agingdeveloper/issues/853)) ([29bcf45](https://github.com/richwklein/agingdeveloper/commit/29bcf45fd7df5d6bfabcf12122c470883947d1b5))
+
+## [5.9.0](https://github.com/richwklein/agingdeveloper/compare/5.8.3...5.9.0) (2026-04-04)
+
+### Miscellaneous Changes
+
+* Article about creating an IRS account and how that reflects on the SAVE Act ([#852](https://github.com/richwklein/agingdeveloper/issues/852)) ([57f3bcf](https://github.com/richwklein/agingdeveloper/commit/57f3bcfc97b649a451b7aeca6f45fad0188dcb13))
+* Bump the eslint group with 2 updates ([#825](https://github.com/richwklein/agingdeveloper/issues/825)) ([768a3f1](https://github.com/richwklein/agingdeveloper/commit/768a3f1b00bdd5b57a64349dc53c3f2b8aa009ed))
+* Bump the github-actions group across 1 directory with 3 updates ([#831](https://github.com/richwklein/agingdeveloper/issues/831)) ([e866c33](https://github.com/richwklein/agingdeveloper/commit/e866c337332c778c94bfb68b6912acb3a21f5dd7))
+
+## [5.8.3](https://github.com/richwklein/agingdeveloper/compare/5.8.2...5.8.3) (2026-03-23)
+
+### Miscellaneous Changes
+
+* Quote for the week of March 23rd, 2026 ([#851](https://github.com/richwklein/agingdeveloper/issues/851)) ([c414ef7](https://github.com/richwklein/agingdeveloper/commit/c414ef7626e81c5ee3a345072b89b973bcebc6ba))
+
+## [5.8.2](https://github.com/richwklein/agingdeveloper/compare/5.8.1...5.8.2) (2026-03-23)
+
+### Miscellaneous Changes
+
+* fixes needed from the switch to github actions for build and deploy ([#850](https://github.com/richwklein/agingdeveloper/issues/850)) ([3182783](https://github.com/richwklein/agingdeveloper/commit/31827834ceaf76b5d04291518df14977a324084b))
+
+## [5.8.1](https://github.com/richwklein/agingdeveloper/compare/5.8.0...5.8.1) (2026-03-21)
+
+### Miscellaneous Changes
+
+* Tag release ([#849](https://github.com/richwklein/agingdeveloper/issues/849)) ([0f6273f](https://github.com/richwklein/agingdeveloper/commit/0f6273f560edd429b8c8567b619e5b6aacd595e5))
+
+## [5.8.0](https://github.com/richwklein/agingdeveloper/compare/5.7.5...5.8.0) (2026-03-21)
+
+### Miscellaneous Changes
+
+* Switch to pnpm as the package manager. ([#848](https://github.com/richwklein/agingdeveloper/issues/848)) ([a3f85c5](https://github.com/richwklein/agingdeveloper/commit/a3f85c50239f89a685a5fee8159cdde73e4e7988))
+* Netlify tagged ([#846](https://github.com/richwklein/agingdeveloper/issues/846)) ([db7c6d8](https://github.com/richwklein/agingdeveloper/commit/db7c6d8f0423e29b44b2e4116a02ac802759c343))
+* Switch to using github actions for build and deploy ([#834](https://github.com/richwklein/agingdeveloper/issues/834)) ([edd867a](https://github.com/richwklein/agingdeveloper/commit/edd867a2dcf7ebe590fafd118bb89b24d9392eba))
+
+## [5.7.5](https://github.com/richwklein/agingdeveloper/compare/5.7.4...5.7.5) (2026-03-16)
+
+### Miscellaneous Changes
+
+* Quote for the week of March 16th, 2026 ([#829](https://github.com/richwklein/agingdeveloper/issues/829)) ([3e7c2a0](https://github.com/richwklein/agingdeveloper/commit/3e7c2a065445288ef216f06b69eae5f2162825dc))
+
+## [5.7.4](https://github.com/richwklein/agingdeveloper/compare/5.7.3...5.7.4) (2026-03-09)
+
+### Miscellaneous Changes
+
+* Quote for the week of March 9th, 2026 ([#828](https://github.com/richwklein/agingdeveloper/issues/828)) ([9d4f75b](https://github.com/richwklein/agingdeveloper/commit/9d4f75b2bc75078d1f77d384064a7f5b2ddd8a35))
+
+## [5.7.3](https://github.com/richwklein/agingdeveloper/compare/5.7.2...5.7.3) (2026-03-02)
+
+### Miscellaneous Changes
+
+* Quote for the week of March 2nd, 2026 ([#827](https://github.com/richwklein/agingdeveloper/issues/827)) ([fbe799c](https://github.com/richwklein/agingdeveloper/commit/fbe799c619961e089e2e67b70eb13431ddc103e8))
+
+## [5.7.2](https://github.com/richwklein/agingdeveloper/compare/5.7.1...5.7.2) (2026-02-23)
+
+### Miscellaneous Changes
+
+* Quote for the week of 2026-02-23 ([#826](https://github.com/richwklein/agingdeveloper/issues/826)) ([50881df](https://github.com/richwklein/agingdeveloper/commit/50881df16e478b466e4b5ef180e6403f7d214a64))
+
+## [5.7.1](https://github.com/richwklein/agingdeveloper/compare/5.7.0...5.7.1) (2026-02-16)
+
+### Miscellaneous Changes
+
+* This weeks quote and updated "popular" articles ([#824](https://github.com/richwklein/agingdeveloper/issues/824)) ([d37f400](https://github.com/richwklein/agingdeveloper/commit/d37f40068e22b6e7f54005d5d800676d414dcd2f))
+
+## [5.7.0](https://github.com/richwklein/agingdeveloper/compare/5.6.5...5.7.0) (2026-02-12)
+
+### Miscellaneous Changes
+
+* Quote of the week 2026-02-12 and a new source type "magazine" ([#823](https://github.com/richwklein/agingdeveloper/issues/823)) ([b1ae542](https://github.com/richwklein/agingdeveloper/commit/b1ae5421fb19bd1dbc8228811d08358d2475c6e5))
+
+## [5.6.5](https://github.com/richwklein/agingdeveloper/compare/5.6.4...5.6.5) (2026-02-02)
+
+### Miscellaneous Changes
+
+* Quote for the week of February 2nd, 2026 ([#822](https://github.com/richwklein/agingdeveloper/issues/822)) ([34b31cd](https://github.com/richwklein/agingdeveloper/commit/34b31cd8d65dd655e64d57e4bbd6f8d8591b80c7))
+
+## [5.6.4](https://github.com/richwklein/agingdeveloper/compare/5.6.3...5.6.4) (2026-01-30)
+
+### Miscellaneous Changes
+
+* Article about "Healthier new year" ([#821](https://github.com/richwklein/agingdeveloper/issues/821)) ([5b3fcbc](https://github.com/richwklein/agingdeveloper/commit/5b3fcbc0681173631f46da3307112e8ca9d91ccb))
+
+## [5.6.3](https://github.com/richwklein/agingdeveloper/compare/5.6.2...5.6.3) (2026-01-26)
+
+### Miscellaneous Changes
+
+* Quote for the week of January 26th, 2026 ([#820](https://github.com/richwklein/agingdeveloper/issues/820)) ([1deff3d](https://github.com/richwklein/agingdeveloper/commit/1deff3d794e69507927885ac3440e5c466ac95f2))
+
+## [5.6.2](https://github.com/richwklein/agingdeveloper/compare/5.6.1...5.6.2) (2026-01-19)
+
+### Miscellaneous Changes
+
+* Quote of the week for January 19th 2026 ([#819](https://github.com/richwklein/agingdeveloper/issues/819)) ([e82938c](https://github.com/richwklein/agingdeveloper/commit/e82938c7e3ee5ace9a429574bf79efffd5d6cc63))
+
+## [5.6.1](https://github.com/richwklein/agingdeveloper/compare/5.6.0...5.6.1) (2026-01-13)
+
+### Miscellaneous Changes
+
+* Quote for the week of January 12, 2026 ([#818](https://github.com/richwklein/agingdeveloper/issues/818)) ([7424465](https://github.com/richwklein/agingdeveloper/commit/74244658e1d8ed93cedb155fd855a68dfc042da8))
+
+## [5.6.0](https://github.com/richwklein/agingdeveloper/compare/5.5.9...5.6.0) (2026-01-11)
+
+### Miscellaneous Changes
+
+* New article on using AI to spot bias ([#817](https://github.com/richwklein/agingdeveloper/issues/817)) ([9a15696](https://github.com/richwklein/agingdeveloper/commit/9a15696cb24b770109b4151ee7dd0cdcf87d701f))
+
+## [5.5.9](https://github.com/richwklein/agingdeveloper/compare/5.5.8...5.5.9) (2026-01-05)
+
+### Miscellaneous Changes
+
+* Quote of the week for January 5th, 2026 ([#816](https://github.com/richwklein/agingdeveloper/issues/816)) ([feed96a](https://github.com/richwklein/agingdeveloper/commit/feed96ae8a1675a204d5f0738d7841dbfecfceef))
+
+## [5.5.8](https://github.com/richwklein/agingdeveloper/compare/5.5.7...5.5.8) (2025-12-29)
+
+### Miscellaneous Changes
+
+* Quote for the week of December 29th, 2025 ([#815](https://github.com/richwklein/agingdeveloper/issues/815)) ([7b07ac4](https://github.com/richwklein/agingdeveloper/commit/7b07ac4156759d1c968a115ed1034fd5474fb366))
+* New article about using emojis in pull request comments ([#814](https://github.com/richwklein/agingdeveloper/issues/814)) ([94f1e54](https://github.com/richwklein/agingdeveloper/commit/94f1e54a6a4b4e7dceff2ad0a97b773054850441))
+
+## [5.5.7](https://github.com/richwklein/agingdeveloper/compare/5.5.6...5.5.7) (2025-12-23)
+
+### Miscellaneous Changes
+
+* Quote for the week of December 22nd, 2025 ([#812](https://github.com/richwklein/agingdeveloper/issues/812)) ([c80f347](https://github.com/richwklein/agingdeveloper/commit/c80f347fbca9c5e8534c039e07e59400a3961c3c))
+
+## [5.5.6](https://github.com/richwklein/agingdeveloper/compare/5.5.5...5.5.6) (2025-12-15)
+
+### Miscellaneous Changes
+
+* Quote for the week of December 15th ([#811](https://github.com/richwklein/agingdeveloper/issues/811)) ([a28f62d](https://github.com/richwklein/agingdeveloper/commit/a28f62d5837a172f67292d7edb80d258a9a0f933))
+* Tweaks to the github actions ([#806](https://github.com/richwklein/agingdeveloper/issues/806)) ([aae03cb](https://github.com/richwklein/agingdeveloper/commit/aae03cb5541b507007dc403d4f83ab8101d7d4db))
+* Fix semver not supported for github actions ([#810](https://github.com/richwklein/agingdeveloper/issues/810)) ([d2864ff](https://github.com/richwklein/agingdeveloper/commit/d2864ff586cb0f778fc6f4639dfcef8371b489ec))
+
+## [5.5.5](https://github.com/richwklein/agingdeveloper/compare/5.5.4...5.5.5) (2025-12-13)
+
+### Miscellaneous Changes
+
+* Dependency cooldown ([#809](https://github.com/richwklein/agingdeveloper/issues/809)) ([1bb319e](https://github.com/richwklein/agingdeveloper/commit/1bb319e7fe4ac753bd3ba2c6c3b36219d07d4455))
+
+## [5.5.4](https://github.com/richwklein/agingdeveloper/compare/5.5.3...5.5.4) (2025-12-08)
+
+### Miscellaneous Changes
+
+* Quote of the week for December 8th, 2025 ([#808](https://github.com/richwklein/agingdeveloper/issues/808)) ([79755c6](https://github.com/richwklein/agingdeveloper/commit/79755c6b0c05214a63b9fc85ce3cef6342bd30bc))
+
+## [5.5.3](https://github.com/richwklein/agingdeveloper/compare/5.5.2...5.5.3) (2025-12-01)
+
+### Miscellaneous Changes
+
+* Quote of the week for 2025-12-01 ([#807](https://github.com/richwklein/agingdeveloper/issues/807)) ([2b2a814](https://github.com/richwklein/agingdeveloper/commit/2b2a814686b54767a0a25bf68ec2aaea3f5ab9e1))
+* Attempting to fix test reporting ([#805](https://github.com/richwklein/agingdeveloper/issues/805)) ([aa32444](https://github.com/richwklein/agingdeveloper/commit/aa32444329ca747dc61600c3e3cd00f77bd6071b))
+* Test coverage reporting ([#785](https://github.com/richwklein/agingdeveloper/issues/785)) ([cb87801](https://github.com/richwklein/agingdeveloper/commit/cb8780199232c43f338295706cb71259f6f76ce7))
+
+## [5.5.2](https://github.com/richwklein/agingdeveloper/compare/5.5.1...5.5.2) (2025-11-24)
+
+### Miscellaneous Changes
+
+* Gracefully handle when the license icon does not exist ([#804](https://github.com/richwklein/agingdeveloper/issues/804)) ([eec9fbe](https://github.com/richwklein/agingdeveloper/commit/eec9fbe66f78ead8c0891ab4e06be96886927009))
+
+## [5.5.1](https://github.com/richwklein/agingdeveloper/compare/5.5.0...5.5.1) (2025-11-24)
+
+### Miscellaneous Changes
+
+* Licensing and Attribution Component ([#803](https://github.com/richwklein/agingdeveloper/issues/803)) ([1177e46](https://github.com/richwklein/agingdeveloper/commit/1177e46fc5e711664efd0c79538b1fda60241a40))
+
+## [5.5.0](https://github.com/richwklein/agingdeveloper/compare/5.4.11...5.5.0) (2025-11-24)
+
+### Miscellaneous Changes
+
+* Upgrade dependencies and publish quote for 2025-11-24 ([#802](https://github.com/richwklein/agingdeveloper/issues/802)) ([55cd9b6](https://github.com/richwklein/agingdeveloper/commit/55cd9b6fbd2e2abb5ed391359baff47e4149c9d8))
+
+## [5.4.11](https://github.com/richwklein/agingdeveloper/compare/5.4.10...5.4.11) (2025-11-17)
+
+### Miscellaneous Changes
+
+* Quote for the week of November 17th, 2025 ([#800](https://github.com/richwklein/agingdeveloper/issues/800)) ([d523e59](https://github.com/richwklein/agingdeveloper/commit/d523e597ad179a378e2da4c4924106f9278518f4))
+
+## [5.4.10](https://github.com/richwklein/agingdeveloper/compare/5.4.9...5.4.10) (2025-11-10)
+
+### Miscellaneous Changes
+
+* Quote of the week - November 10th, 2025 ([#798](https://github.com/richwklein/agingdeveloper/issues/798)) ([fcb3c60](https://github.com/richwklein/agingdeveloper/commit/fcb3c6048800b05e9f64ae581ccc58e367017816))
+* Quote of the week for 2025-11-04 ([#797](https://github.com/richwklein/agingdeveloper/issues/797)) ([4fa526c](https://github.com/richwklein/agingdeveloper/commit/4fa526ca52a53e0fd29b08e47c2ab6b6876cb2f4))
+
+## [5.4.9](https://github.com/richwklein/agingdeveloper/compare/5.4.8...5.4.9) (2025-10-27)
+
+### Miscellaneous Changes
+
+* Quote of the Week 2025-10-27 ([#794](https://github.com/richwklein/agingdeveloper/issues/794)) ([436f3c9](https://github.com/richwklein/agingdeveloper/commit/436f3c9466afb91c053e69653ebeaf1e040dd17a))
+
+## [5.4.8](https://github.com/richwklein/agingdeveloper/compare/5.4.7...5.4.8) (2025-10-13)
+
+### Miscellaneous Changes
+
+* Quote for the week of 2025-10-13 ([#791](https://github.com/richwklein/agingdeveloper/issues/791)) ([7941669](https://github.com/richwklein/agingdeveloper/commit/79416691d967e83c9860ab46896a02b199a376c7))
+
+## [5.4.7](https://github.com/richwklein/agingdeveloper/compare/5.4.6...5.4.7) (2025-10-07)
+
+### Miscellaneous Changes
+
+* Change dependabot interval and ignore patch versions ([#789](https://github.com/richwklein/agingdeveloper/issues/789)) ([f589c8a](https://github.com/richwklein/agingdeveloper/commit/f589c8a484e40554226398717d7030eaf497e2de))
+
+## [5.4.6](https://github.com/richwklein/agingdeveloper/compare/5.4.5...5.4.6) (2025-10-06)
+
+### Miscellaneous Changes
+
+* Quote of the week for October 6th, 2025 ([#788](https://github.com/richwklein/agingdeveloper/issues/788)) ([b28e603](https://github.com/richwklein/agingdeveloper/commit/b28e603021855c50bb88fdc6d4e8bfdfd79968c9))
+
+## [5.4.5](https://github.com/richwklein/agingdeveloper/compare/5.4.4...5.4.5) (2025-09-29)
+
+### Miscellaneous Changes
+
+* Quote for the week of 2025-09-29 ([#787](https://github.com/richwklein/agingdeveloper/issues/787)) ([a7d1225](https://github.com/richwklein/agingdeveloper/commit/a7d1225adc292e3e83656040f51f468c838e3582))
+
+## [5.4.4](https://github.com/richwklein/agingdeveloper/compare/5.4.3...5.4.4) (2025-09-22)
+
+### Miscellaneous Changes
+
+* Quote of the Week for 2025-09-21 ([#786](https://github.com/richwklein/agingdeveloper/issues/786)) ([a282cb7](https://github.com/richwklein/agingdeveloper/commit/a282cb7fe40d0fc7f6955b443ac8986344fada45))
+
+## [5.4.3](https://github.com/richwklein/agingdeveloper/compare/5.4.2...5.4.3) (2025-09-15)
+
+### Miscellaneous Changes
+
+* Quote of the week for 2025-09-15 ([#784](https://github.com/richwklein/agingdeveloper/issues/784)) ([5b3a8d8](https://github.com/richwklein/agingdeveloper/commit/5b3a8d8e36081f17c573f32b770567c867e923e4))
+
+## [5.4.2](https://github.com/richwklein/agingdeveloper/compare/5.4.1...5.4.2) (2025-09-08)
+
+### Miscellaneous Changes
+
+* Quote of the week for 20225-09-08 ([#782](https://github.com/richwklein/agingdeveloper/issues/782)) ([e4f97d8](https://github.com/richwklein/agingdeveloper/commit/e4f97d806220831509710fc3003c3d88ab642e0f))
+* Quote of the week for 2025-09-01 ([#780](https://github.com/richwklein/agingdeveloper/issues/780)) ([8636d59](https://github.com/richwklein/agingdeveloper/commit/8636d59f77f02ab370ac0f44ae7db2c0ea3adee1))
+* Bump the github-actions group across 1 directory with 2 updates ([#776](https://github.com/richwklein/agingdeveloper/issues/776)) ([6e1deee](https://github.com/richwklein/agingdeveloper/commit/6e1deee8bb6db39e3a22a1bc3b0562c147df7a1a))
+
+## [5.4.1](https://github.com/richwklein/agingdeveloper/compare/5.4.0...5.4.1) (2025-08-25)
+
+### Miscellaneous Changes
+
+* Quote of the week for 2025-08-25 ([#779](https://github.com/richwklein/agingdeveloper/issues/779)) ([f322d90](https://github.com/richwklein/agingdeveloper/commit/f322d902f7258053ae639e85e7f0380942c50a27))
+
+## [5.4.0](https://github.com/richwklein/agingdeveloper/compare/5.3.2...5.4.0) (2025-08-20)
+
+### Miscellaneous Changes
+
+* Dependency upgrade ([#778](https://github.com/richwklein/agingdeveloper/issues/778)) ([d55785d](https://github.com/richwklein/agingdeveloper/commit/d55785df4bd2002cf4c0c94d2a71e6bf5b067af5))
+
+## [5.3.2](https://github.com/richwklein/agingdeveloper/compare/5.3.1...5.3.2) (2025-08-18)
+
+### Miscellaneous Changes
+
+* Quote of the week for 2025-08-18 ([#777](https://github.com/richwklein/agingdeveloper/issues/777)) ([841d31c](https://github.com/richwklein/agingdeveloper/commit/841d31cccdda9708c608f2e2c3518a4ee21786b3))
+
+## [5.3.1](https://github.com/richwklein/agingdeveloper/compare/5.3.0...5.3.1) (2025-08-04)
+
+### Miscellaneous Changes
+
+* Quote of the week 2025-08-04 ([#774](https://github.com/richwklein/agingdeveloper/issues/774)) ([b85fd4b](https://github.com/richwklein/agingdeveloper/commit/b85fd4b0b6fb621583d4a35689eb0386b3656dda))
+
+## [5.3.0](https://github.com/richwklein/agingdeveloper/compare/5.2.11...5.3.0) (2025-07-29)
+
+### Miscellaneous Changes
+
+* Ai prompt post ([#773](https://github.com/richwklein/agingdeveloper/issues/773)) ([236dea3](https://github.com/richwklein/agingdeveloper/commit/236dea349c5c296b9f619eb2f086f5fc239c8fd4))
+
+## [5.2.11](https://github.com/richwklein/agingdeveloper/compare/5.2.10...5.2.11) (2025-07-28)
+
+### Miscellaneous Changes
+
+* Quote of the week: 2025-07-28 ([#772](https://github.com/richwklein/agingdeveloper/issues/772)) ([0e43e2e](https://github.com/richwklein/agingdeveloper/commit/0e43e2e81f2ad771c8e53ef83216d3ad209b3a0c))
+
+## [5.2.10](https://github.com/richwklein/agingdeveloper/compare/5.2.9...5.2.10) (2025-07-21)
+
+### Miscellaneous Changes
+
+* Quote of the week 2025-07-21 ([#771](https://github.com/richwklein/agingdeveloper/issues/771)) ([d666fc1](https://github.com/richwklein/agingdeveloper/commit/d666fc1e615a3d0fd57dfcb5257d628410b7bb4c))
+
+## [5.2.9](https://github.com/richwklein/agingdeveloper/compare/5.2.8...5.2.9) (2025-07-14)
+
+### Miscellaneous Changes
+
+* Quote of the Week 2025-07-14 ([#770](https://github.com/richwklein/agingdeveloper/issues/770)) ([d4a3559](https://github.com/richwklein/agingdeveloper/commit/d4a3559fb5d829fc6e3304bc95ae96e036ce2d9f))
+
+## [5.2.8](https://github.com/richwklein/agingdeveloper/compare/5.2.7...5.2.8) (2025-07-09)
+
+### Miscellaneous Changes
+
+* Quote of the week (2025-07-07) ([b7f95d6](https://github.com/richwklein/agingdeveloper/commit/b7f95d6133e1a70de59cf4508626ab54215c920b))
+
+## [5.2.7](https://github.com/richwklein/agingdeveloper/compare/5.2.6...5.2.7) (2025-07-04)
+
+### Miscellaneous Changes
+
+* Improve testing stance ([#726](https://github.com/richwklein/agingdeveloper/issues/726)) ([2a98cb0](https://github.com/richwklein/agingdeveloper/commit/2a98cb0c9140081521999195844f354eafcfa378))
+
+## [5.2.6](https://github.com/richwklein/agingdeveloper/compare/5.2.5...5.2.6) (2025-06-30)
+
+### Miscellaneous Changes
+
+* Quote of the Week for June 30th ([#768](https://github.com/richwklein/agingdeveloper/issues/768)) ([2e311c7](https://github.com/richwklein/agingdeveloper/commit/2e311c749631436ab81b6429f2203bcef57382e9))
+
+## [5.2.5](https://github.com/richwklein/agingdeveloper/compare/5.2.4...5.2.5) (2025-06-30)
+
+### Miscellaneous Changes
+
+* Upgrade frameworks ([#769](https://github.com/richwklein/agingdeveloper/issues/769)) ([49ecac2](https://github.com/richwklein/agingdeveloper/commit/49ecac2dd2bf8bba2c83a6bdde1b5955a0a337c1))
+* Quote for 2025-06-23 ([#767](https://github.com/richwklein/agingdeveloper/issues/767)) ([4bdd1c0](https://github.com/richwklein/agingdeveloper/commit/4bdd1c037aaeac053668a8a36373265fde32c892))
+
+## [5.2.4](https://github.com/richwklein/agingdeveloper/compare/5.2.3...5.2.4) (2025-06-09)
+
+### Miscellaneous Changes
+
+* Quote of the week 2025-06-09 ([#766](https://github.com/richwklein/agingdeveloper/issues/766)) ([740fd8d](https://github.com/richwklein/agingdeveloper/commit/740fd8d055f4f2f969ac048f90c71bb32ec7a9c4))
+
+## [5.2.3](https://github.com/richwklein/agingdeveloper/compare/5.2.2...5.2.3) (2025-06-03)
+
+### Miscellaneous Changes
+
+* Quote of the week for June 2nd, 2025 ([#765](https://github.com/richwklein/agingdeveloper/issues/765)) ([933a00b](https://github.com/richwklein/agingdeveloper/commit/933a00be11dda0e3de4beddc6e2992fed69ad9c6))
+
+## [5.2.2](https://github.com/richwklein/agingdeveloper/compare/5.2.1...5.2.2) (2025-05-26)
+
+### Miscellaneous Changes
+
+* Quote of the week May 26th, 2025 ([#764](https://github.com/richwklein/agingdeveloper/issues/764)) ([961feec](https://github.com/richwklein/agingdeveloper/commit/961feec920c188b52f061431b61a34ce6c454560))
+* 2025-05-20 Quote ([#763](https://github.com/richwklein/agingdeveloper/issues/763)) ([8d32aae](https://github.com/richwklein/agingdeveloper/commit/8d32aae9248f8d15e0ca34fb10ffc999e1b123d6))
+
+## [5.2.1](https://github.com/richwklein/agingdeveloper/compare/5.2.0...5.2.1) (2025-05-12)
+
+### Miscellaneous Changes
+
+* Quote for the week of 05/12/2025 ([#762](https://github.com/richwklein/agingdeveloper/issues/762)) ([f462172](https://github.com/richwklein/agingdeveloper/commit/f4621721202cd80ee247df8de9eb8d20d99290fd))
+
+## [5.2.0](https://github.com/richwklein/agingdeveloper/compare/5.1.5...5.2.0) (2025-05-10)
+
+### Miscellaneous Changes
+
+* Fix validation errors in the RSS and Atom Feeds ([#761](https://github.com/richwklein/agingdeveloper/issues/761)) ([8611eb0](https://github.com/richwklein/agingdeveloper/commit/8611eb0a241ab536143f62da0982ca93a5dba4cb))
+* Bump feed from 4.2.2 to 5.0.0 ([#759](https://github.com/richwklein/agingdeveloper/issues/759)) ([00e2f9f](https://github.com/richwklein/agingdeveloper/commit/00e2f9f46c30976b60fa2a17fdd519f6ad8f3f11))
+
+## [5.1.5](https://github.com/richwklein/agingdeveloper/compare/5.1.4...5.1.5) (2025-05-05)
+
+### Miscellaneous Changes
+
+* Quote for the week of May 5th ([#758](https://github.com/richwklein/agingdeveloper/issues/758)) ([943f68b](https://github.com/richwklein/agingdeveloper/commit/943f68b942c326ccac2c4ffb957af06f8206373a))
+* Quote for the week of 2025-04-13 ([#757](https://github.com/richwklein/agingdeveloper/issues/757)) ([e84e3fb](https://github.com/richwklein/agingdeveloper/commit/e84e3fbfc8b879e4a78f8a5ae1568cb41f6ca2f0))
+
+## [5.1.4](https://github.com/richwklein/agingdeveloper/compare/5.1.3...5.1.4) (2025-03-31)
+
+### Miscellaneous Changes
+
+* Quote of the week 2025-03-31 ([#756](https://github.com/richwklein/agingdeveloper/issues/756)) ([083f86e](https://github.com/richwklein/agingdeveloper/commit/083f86e392b4b363b046ae2006fd4dfd42703242))
+
+## [5.1.3](https://github.com/richwklein/agingdeveloper/compare/5.1.2...5.1.3) (2025-03-26)
+
+### Miscellaneous Changes
+
+* Quote for the week of 03/24 ([#755](https://github.com/richwklein/agingdeveloper/issues/755)) ([f9edcac](https://github.com/richwklein/agingdeveloper/commit/f9edcaceb53443cac64770336283c64250858365))
+
+## [5.1.2](https://github.com/richwklein/agingdeveloper/compare/5.1.1...5.1.2) (2025-03-17)
+
+### Miscellaneous Changes
+
+* Quote for the week of 2025-03-17 ([#754](https://github.com/richwklein/agingdeveloper/issues/754)) ([4df7c20](https://github.com/richwklein/agingdeveloper/commit/4df7c2063caed69f1d3d61c85a1b582b5ee8b4ff))
+
+## [5.1.1](https://github.com/richwklein/agingdeveloper/compare/5.0.1...5.1.1) (2025-03-15)
+
+### Miscellaneous Changes
+
+* Create the post slug based on the file path ([#753](https://github.com/richwklein/agingdeveloper/issues/753)) ([2e7d777](https://github.com/richwklein/agingdeveloper/commit/2e7d7771577427c790e45ba6cb757c1fce5c69cc))
+* Add an LLM disclaimer widget ([#752](https://github.com/richwklein/agingdeveloper/issues/752)) ([00513c2](https://github.com/richwklein/agingdeveloper/commit/00513c25f1a9c97837a1e5478304e66c80a08554))
+
+## [5.0.1](https://github.com/richwklein/agingdeveloper/compare/5.0.0...5.0.1) (2025-03-02)
+
+### Miscellaneous Changes
+
+* Quote for the week of 03/03 ([#751](https://github.com/richwklein/agingdeveloper/issues/751)) ([efb71f0](https://github.com/richwklein/agingdeveloper/commit/efb71f0f0ebb5474c3eceeaf0ee9d10fa5f0a203))
+
+## [5.0.0](https://github.com/richwklein/agingdeveloper/compare/4.3.2...5.0.0) (2025-02-27)
+
+### Miscellaneous Changes
+
+* Upgrade astro and tailwind ([#749](https://github.com/richwklein/agingdeveloper/issues/749)) ([64e91ae](https://github.com/richwklein/agingdeveloper/commit/64e91ae3e5898f6e1c3f512c04411361a59bc218))
+
+## [4.3.2](https://github.com/richwklein/agingdeveloper/compare/4.3.1...4.3.2) (2025-02-24)
+
+### Miscellaneous Changes
+
+* Quote for the week of 02/24/2025 ([#746](https://github.com/richwklein/agingdeveloper/issues/746)) ([1343bc0](https://github.com/richwklein/agingdeveloper/commit/1343bc09944a3c98a62a7055acfc1390bde70304))
+* Quote for the week of 2025-02-17 ([#744](https://github.com/richwklein/agingdeveloper/issues/744)) ([2d905a5](https://github.com/richwklein/agingdeveloper/commit/2d905a5860a68ac34df537ad36db86ee58e3d195))
+
+## [4.3.1](https://github.com/richwklein/agingdeveloper/compare/4.3.0...4.3.1) (2025-02-11)
+
+### Miscellaneous Changes
+
+* Add this weeks quote ([#743](https://github.com/richwklein/agingdeveloper/issues/743)) ([8f5ac50](https://github.com/richwklein/agingdeveloper/commit/8f5ac505b83825e050e06be350e590a0b58712a1))
+
+## [4.3.0](https://github.com/richwklein/agingdeveloper/compare/4.2.9...4.3.0) (2025-02-01)
+
+### Miscellaneous Changes
+
+* New article on my git-cleanup script ([#739](https://github.com/richwklein/agingdeveloper/issues/739)) ([296808b](https://github.com/richwklein/agingdeveloper/commit/296808bcf64c0170ce8a7f4bd62176fad30afc1b))
+
+## [4.2.9](https://github.com/richwklein/agingdeveloper/compare/4.2.8...4.2.9) (2025-01-29)
+
+### Miscellaneous Changes
+
+* Quote for the week ending February 1st ([#735](https://github.com/richwklein/agingdeveloper/issues/735)) ([bd2a4d1](https://github.com/richwklein/agingdeveloper/commit/bd2a4d10f2b043481fc33d377d849161ec30976c))
+
+## [4.2.8](https://github.com/richwklein/agingdeveloper/compare/4.2.7...4.2.8) (2025-01-19)
+
+### Miscellaneous Changes
+
+* Quote for this week ([#734](https://github.com/richwklein/agingdeveloper/issues/734)) ([ce97a9b](https://github.com/richwklein/agingdeveloper/commit/ce97a9b81c369cc87f926728fb0c781c9d4f8dfa))
+
+## [4.2.7](https://github.com/richwklein/agingdeveloper/compare/4.2.6...4.2.7) (2025-01-17)
+
+### Miscellaneous Changes
+
+* Do not run the license report on forks ([#732](https://github.com/richwklein/agingdeveloper/issues/732)) ([29f9962](https://github.com/richwklein/agingdeveloper/commit/29f9962f46c11cff852c593d6cca6b25a94aece0))
+
+## [4.2.6](https://github.com/richwklein/agingdeveloper/compare/4.2.5...4.2.6) (2025-01-17)
+
+### Miscellaneous Changes
+
+* Bump the vitest group across 1 directory with 2 updates ([#731](https://github.com/richwklein/agingdeveloper/issues/731)) ([61b4e46](https://github.com/richwklein/agingdeveloper/commit/61b4e4614fe47f1e5cc82df708abce02970e9de2))
+
+## [4.2.5](https://github.com/richwklein/agingdeveloper/compare/4.2.4...4.2.5) (2025-01-13)
+
+### Miscellaneous Changes
+
+* Quote for the week of 2024-01-13 ([#729](https://github.com/richwklein/agingdeveloper/issues/729)) ([8bb1b35](https://github.com/richwklein/agingdeveloper/commit/8bb1b355cc04c5eb7fd8386f8dee96e508a63876))
+
+## [4.2.4](https://github.com/richwklein/agingdeveloper/compare/4.2.3...4.2.4) (2025-01-06)
+
+### Miscellaneous Changes
+
+* Add this weeks quote ([57d3991](https://github.com/richwklein/agingdeveloper/commit/57d39914210800e151d769d58f246237bebbf243))
+
+## [4.2.3](https://github.com/richwklein/agingdeveloper/compare/4.2.2...4.2.3) (2024-12-30)
+
+### Miscellaneous Changes
+
+* Quote of the week ([#728](https://github.com/richwklein/agingdeveloper/issues/728)) ([ca5c771](https://github.com/richwklein/agingdeveloper/commit/ca5c7716771acd852ed67a19acb76355469fe164))
+
+## [4.2.2](https://github.com/richwklein/agingdeveloper/compare/4.2.1...4.2.2) (2024-12-30)
+
+### Miscellaneous Changes
+
+* patch version bump ([8a71294](https://github.com/richwklein/agingdeveloper/commit/8a71294572eb953f1c052f6d331bfe17812acb56))
+
+## [4.2.1](https://github.com/richwklein/agingdeveloper/compare/4.2.0...4.2.1) (2024-12-23)
+
+### Miscellaneous Changes
+
+* Quote for this week ([#727](https://github.com/richwklein/agingdeveloper/issues/727)) ([b3d119e](https://github.com/richwklein/agingdeveloper/commit/b3d119e8b98b91924fe404e46e8439bbcff123a7))
+
+## [4.2.0](https://github.com/richwklein/agingdeveloper/compare/4.1.2...4.2.0) (2024-12-21)
+
+### Miscellaneous Changes
+
+* Add a typeahead search to the 404 page to help find what they are lookking for ([#725](https://github.com/richwklein/agingdeveloper/issues/725)) ([b01d59a](https://github.com/richwklein/agingdeveloper/commit/b01d59a3232eb739ab1f66e6c4325185463021aa))
+
+## [4.1.2](https://github.com/richwklein/agingdeveloper/compare/4.1.1...4.1.2) (2024-12-18)
+
+### Miscellaneous Changes
+
+* Add a github workflow to report licenses ([#724](https://github.com/richwklein/agingdeveloper/issues/724)) ([59c96e1](https://github.com/richwklein/agingdeveloper/commit/59c96e16beb9f3416f796e9d690aaf0117d10fa5))
+
+## [4.1.1](https://github.com/richwklein/agingdeveloper/compare/4.1.0...4.1.1) (2024-12-16)
+
+### Miscellaneous Changes
+
+* Quote for the week ([#722](https://github.com/richwklein/agingdeveloper/issues/722)) ([4193ccb](https://github.com/richwklein/agingdeveloper/commit/4193ccb6af64bd2c2feec5435e2ed680e2c5c2d8))
+
+## [4.1.0](https://github.com/richwklein/agingdeveloper/compare/4.0.0...4.1.0) (2024-12-11)
+
+### Miscellaneous Changes
+
+* Create a virtual quote board ([#715](https://github.com/richwklein/agingdeveloper/issues/715)) ([ee45f0d](https://github.com/richwklein/agingdeveloper/commit/ee45f0d8a1c1a4f9a3bb74ebccd91670a3d2a727))
+
+## [4.0.0](https://github.com/richwklein/agingdeveloper/compare/3.5.3...4.0.0) (2024-12-10)
+
+### Miscellaneous Changes
+
+* Update Astro to version 5.0.* ([#717](https://github.com/richwklein/agingdeveloper/issues/717)) ([faffed1](https://github.com/richwklein/agingdeveloper/commit/faffed15117c20655c4a24af6465736b32d9b3a9))
+
+## [3.5.3](https://github.com/richwklein/agingdeveloper/compare/3.5.2...3.5.3) (2024-11-21)
+
+### Miscellaneous Changes
+
+* Update dependencies to pick up typescript / eslint bug fix ([#714](https://github.com/richwklein/agingdeveloper/issues/714)) ([9ffb9de](https://github.com/richwklein/agingdeveloper/commit/9ffb9ded6ec5bc49301d69d2aee4e3e393e870f7))
+
+## [3.5.2](https://github.com/richwklein/agingdeveloper/compare/3.5.1...3.5.2) (2024-11-16)
+
+### Miscellaneous Changes
+
+* Minor Tweaks ([#713](https://github.com/richwklein/agingdeveloper/issues/713)) ([514a23a](https://github.com/richwklein/agingdeveloper/commit/514a23a898b4e0dc96740b9b38565dff27052ae9))
+
+## [3.5.1](https://github.com/richwklein/agingdeveloper/compare/3.5.0...3.5.1) (2024-11-03)
+
+### Miscellaneous Changes
+
+* Article on using Umami to track events on the site ([#712](https://github.com/richwklein/agingdeveloper/issues/712)) ([c42bdc9](https://github.com/richwklein/agingdeveloper/commit/c42bdc9a5cb961ae2ee04ef3cbc831f88ec7f2bc))
+
+## [3.5.0](https://github.com/richwklein/agingdeveloper/compare/3.4.2...3.5.0) (2024-11-03)
+
+### Miscellaneous Changes
+
+* improve layout performance ([#711](https://github.com/richwklein/agingdeveloper/issues/711)) ([7fb7acd](https://github.com/richwklein/agingdeveloper/commit/7fb7acdce6ee580a127b30c8135b4e1af5867e54))
+
+## [3.4.2](https://github.com/richwklein/agingdeveloper/compare/3.4.1...3.4.2) (2024-11-02)
+
+### Miscellaneous Changes
+
+* Add an alert component that can be used in posts ([#710](https://github.com/richwklein/agingdeveloper/issues/710)) ([3f7097b](https://github.com/richwklein/agingdeveloper/commit/3f7097b6175db58bfaf4857244746ce3049d93f9))
+
+## [3.4.1](https://github.com/richwklein/agingdeveloper/compare/3.4.0...3.4.1) (2024-09-06)
+
+### Miscellaneous Changes
+
+* Improve linting stance by adding a11y ([#709](https://github.com/richwklein/agingdeveloper/issues/709)) ([adfd0d9](https://github.com/richwklein/agingdeveloper/commit/adfd0d9b7bbadf6642a92563bd27e2d323185cd0))
+* Minor fixes for crawling and lighthouse issues ([#707](https://github.com/richwklein/agingdeveloper/issues/707)) ([096b38b](https://github.com/richwklein/agingdeveloper/commit/096b38b4758971d2bed820fd6454ca651f193d09))
+* deal with trailingslash inconsistency ([#706](https://github.com/richwklein/agingdeveloper/issues/706)) ([f7f0b58](https://github.com/richwklein/agingdeveloper/commit/f7f0b5887fb382e51e8242a2c960ee827906f9e5))
+
+## [3.4.0](https://github.com/richwklein/agingdeveloper/compare/3.3.0...3.4.0) (2024-08-20)
+
+### Miscellaneous Changes
+
+* Add popular articles component ([bc06c63](https://github.com/richwklein/agingdeveloper/commit/bc06c636b6a7eb79a0f20b1b52992bb068ddbbdc))
+
+## [3.3.0](https://github.com/richwklein/agingdeveloper/compare/3.2.0...3.3.0) (2024-08-18)
+
+### Miscellaneous Changes
+
+* Recent articles component ([#705](https://github.com/richwklein/agingdeveloper/issues/705)) ([894c04f](https://github.com/richwklein/agingdeveloper/commit/894c04f09a93333918843549ba016a6d20ece790))
+
+## [3.2.0](https://github.com/richwklein/agingdeveloper/compare/3.1.0...3.2.0) (2024-08-18)
+
+### Miscellaneous Changes
+
+* Add support for related articles ([#703](https://github.com/richwklein/agingdeveloper/issues/703)) ([07314bc](https://github.com/richwklein/agingdeveloper/commit/07314bc434da316dc02057dbc24f571cc59cdbae))
+
+## [3.1.0](https://github.com/richwklein/agingdeveloper/compare/3.0.2...3.1.0) (2024-08-18)
+
+### Miscellaneous Changes
+
+* Fix for keybase file being missing and some settings cleanup ([#702](https://github.com/richwklein/agingdeveloper/issues/702)) ([de29254](https://github.com/richwklein/agingdeveloper/commit/de29254239158f13afeff4d9ffa7b8c54bf678a3))
+
+## [3.0.2](https://github.com/richwklein/agingdeveloper/compare/3.0.1...3.0.2) (2024-08-17)
+
+### Miscellaneous Changes
+
+* Switch from overflow to scroll-gutter ([#701](https://github.com/richwklein/agingdeveloper/issues/701)) ([18a5171](https://github.com/richwklein/agingdeveloper/commit/18a5171bf6ec29e7abc35d2176d87f3b38c1aeae))
+* Bump @astrojs/check from 0.8.3 to 0.9.2 ([#696](https://github.com/richwklein/agingdeveloper/issues/696)) ([9f6e3f2](https://github.com/richwklein/agingdeveloper/commit/9f6e3f28f1bbac5c2d710b06475db303412663ff))
+* Bump the prettier group with 2 updates ([#695](https://github.com/richwklein/agingdeveloper/issues/695)) ([280f005](https://github.com/richwklein/agingdeveloper/commit/280f00593b796754abb5e22f2f5efb0bb24c736b))
+
+## [3.0.1](https://github.com/richwklein/agingdeveloper/compare/3.0.0...3.0.1) (2024-08-17)
+
+### Miscellaneous Changes
+
+* Split the coverage reporting from the testing ([#700](https://github.com/richwklein/agingdeveloper/issues/700)) ([2161f06](https://github.com/richwklein/agingdeveloper/commit/2161f0684062c223a897c0028c46fce4687ab1bc))
+* Update astro article with fixes ([#698](https://github.com/richwklein/agingdeveloper/issues/698)) ([1101cff](https://github.com/richwklein/agingdeveloper/commit/1101cffa12ec0d45f73d7cf2c6b505ae5f93bbae))
+
+## [3.0.0](https://github.com/richwklein/agingdeveloper/compare/3.0.0-alpha1...3.0.0) (2024-08-16)
+
+### Miscellaneous Changes
+
+* cut the full tag ([#697](https://github.com/richwklein/agingdeveloper/issues/697)) ([13f36e9](https://github.com/richwklein/agingdeveloper/commit/13f36e926a3a0e86ee53bb75d83d56e13163a762))
+
+## [3.0.0-alpha1](https://github.com/richwklein/agingdeveloper/compare/2.3.1...3.0.0-alpha1) (2024-08-16)
+
+### Miscellaneous Changes
+
+* Astro build ([#668](https://github.com/richwklein/agingdeveloper/issues/668)) ([12e888e](https://github.com/richwklein/agingdeveloper/commit/12e888ee22f6f6b513a49393b728938d80683ef6))
+* Bump actions/checkout from 4.1.6 to 4.1.7 in the github-actions group ([#663](https://github.com/richwklein/agingdeveloper/issues/663)) ([383cb23](https://github.com/richwklein/agingdeveloper/commit/383cb2300976d896ff97207264a23d7ac08fb4ee))
+
+## [2.3.1](https://github.com/richwklein/agingdeveloper/compare/2.3.0...2.3.1) (2024-06-08)
+
+### Miscellaneous Changes
+
+* Launch command ([#662](https://github.com/richwklein/agingdeveloper/issues/662)) ([b112385](https://github.com/richwklein/agingdeveloper/commit/b1123855fb2dfd68223dc15d0d5c85381a076fa9))
+* Bump @testing-library/react from 15.0.7 to 16.0.0 ([#660](https://github.com/richwklein/agingdeveloper/issues/660)) ([0541725](https://github.com/richwklein/agingdeveloper/commit/054172504fa8eaa8751ee74a53b2607631aa4036))
+* Bump actions/checkout from 4.1.4 to 4.1.6 in the github-actions group across 1 directory ([#658](https://github.com/richwklein/agingdeveloper/issues/658)) ([61f7bd9](https://github.com/richwklein/agingdeveloper/commit/61f7bd9b1bc43f165994410bd3dcf7385a33bdce))
+* Bump actions/checkout from 4.1.3 to 4.1.4 in the github-actions group ([#655](https://github.com/richwklein/agingdeveloper/issues/655)) ([d4a29bf](https://github.com/richwklein/agingdeveloper/commit/d4a29bfff88a7485729434b9bb590e3b0ea0db50))
+* Bump actions/checkout from 4.1.2 to 4.1.3 in the github-actions group ([#652](https://github.com/richwklein/agingdeveloper/issues/652)) ([1fb7845](https://github.com/richwklein/agingdeveloper/commit/1fb784508a71260698dff259820595c624387782))
+* Bump @testing-library/react from 14.3.1 to 15.0.1 ([#651](https://github.com/richwklein/agingdeveloper/issues/651)) ([d30ee8d](https://github.com/richwklein/agingdeveloper/commit/d30ee8d5d754a44225a909e60308bcfe86f44705))
+* Bump the github-actions group with 1 update ([#647](https://github.com/richwklein/agingdeveloper/issues/647)) ([d45e8cd](https://github.com/richwklein/agingdeveloper/commit/d45e8cdd6f78b4398bb24b529b74dcf882787c37))
+* Bump slug from 8.2.3 to 9.0.0 ([#646](https://github.com/richwklein/agingdeveloper/issues/646)) ([75ea59a](https://github.com/richwklein/agingdeveloper/commit/75ea59a32874747079b0e21d8c3317e6920de5d7))
+* Bump the github-actions group with 1 update ([#644](https://github.com/richwklein/agingdeveloper/issues/644)) ([6643bcb](https://github.com/richwklein/agingdeveloper/commit/6643bcb60940b1f59e2f7ac6e725eb2cb5055c6a))
+
+## [2.3.0](https://github.com/richwklein/agingdeveloper/compare/2.2.0...2.3.0) (2024-02-12)
+
+### Miscellaneous Changes
+
+* Bump the package version to cut a new release ([bbeb795](https://github.com/richwklein/agingdeveloper/commit/bbeb795075593be4b5f96760cd2817fc1de35fac))
+* Bump eslint-plugin-simple-import-sort from 11.0.0 to 12.0.0 ([#641](https://github.com/richwklein/agingdeveloper/issues/641)) ([c36270a](https://github.com/richwklein/agingdeveloper/commit/c36270a17c808d3b7c69aedd4646040ecc9db83f))
+* New article on fixing exif dates in videos ([#640](https://github.com/richwklein/agingdeveloper/issues/640)) ([ab591cc](https://github.com/richwklein/agingdeveloper/commit/ab591cc854b5214ce0c40a652415b0a043edad83))
+* Fix where the page header overlaps content on small screens ([#639](https://github.com/richwklein/agingdeveloper/issues/639)) ([d5a6815](https://github.com/richwklein/agingdeveloper/commit/d5a6815f5574f45bbee081dc948f78588217cabf))
+* Bump eslint-plugin-simple-import-sort from 10.0.0 to 11.0.0 ([#638](https://github.com/richwklein/agingdeveloper/issues/638)) ([4946c44](https://github.com/richwklein/agingdeveloper/commit/4946c449299be7e16ec084a7403efa37024eacbd))
+* move code linting to a github action ([#635](https://github.com/richwklein/agingdeveloper/issues/635)) ([0408479](https://github.com/richwklein/agingdeveloper/commit/0408479edd9c5461cf9894a828f593b2075ff0bc))
+
+## [2.2.0](https://github.com/richwklein/agingdeveloper/compare/2.1.3...2.2.0) (2024-01-27)
+
+### Miscellaneous Changes
+
+* Re-implement the scroll to top behavior ([#634](https://github.com/richwklein/agingdeveloper/issues/634)) ([91dd62e](https://github.com/richwklein/agingdeveloper/commit/91dd62e1f29097b6812f05b3f6276cde3a8ef6d9))
+
+## [2.1.3](https://github.com/richwklein/agingdeveloper/compare/2.1.2...2.1.3) (2024-01-26)
+
+### Miscellaneous Changes
+
+* Update package.json ([624db1e](https://github.com/richwklein/agingdeveloper/commit/624db1ed91896e3bbdae9d4ec33da66a026b1716))
+* Re-Feed support ([#633](https://github.com/richwklein/agingdeveloper/issues/633)) ([d4a98c8](https://github.com/richwklein/agingdeveloper/commit/d4a98c8f1737301149d99a048f9df16ede717220))
+* Add Breadcrumb rich schema ([#631](https://github.com/richwklein/agingdeveloper/issues/631)) ([c6870ff](https://github.com/richwklein/agingdeveloper/commit/c6870ff9c029ef889b7a2d41e240681f57e3df7a))
+
+## [2.1.2](https://github.com/richwklein/agingdeveloper/compare/2.1.1...2.1.2) (2024-01-24)
+
+### Miscellaneous Changes
+
+* Fix unit tests ([1da8139](https://github.com/richwklein/agingdeveloper/commit/1da81390ca3cc14c663ce9195ee81d4aed317c4e))
+* Fix unit tests ([fecc711](https://github.com/richwklein/agingdeveloper/commit/fecc711dfb5b9d1454e4e1e0f06a1dda4a8dcac3))
+* Fix tests ([523a8bc](https://github.com/richwklein/agingdeveloper/commit/523a8bca9fe3cd4813b7913b2fcc04c2d54b1ff4))
+* Fix failing unit tests ([999b4e9](https://github.com/richwklein/agingdeveloper/commit/999b4e9f44dd27f01544ae98dbefd9454eb54652))
+* Update documentation ([e525af4](https://github.com/richwklein/agingdeveloper/commit/e525af4dfc372cc2b413b99d1fa84664893e1854))
+* Add article seo and semantic tags ([25c726b](https://github.com/richwklein/agingdeveloper/commit/25c726b26a9531c8b5360a17cfc3a15f39a70b07))
+
+## [2.1.1](https://github.com/richwklein/agingdeveloper/compare/2.1.0...2.1.1) (2024-01-24)
+
+### Miscellaneous Changes
+
+* Get profile seo working ([b45eecf](https://github.com/richwklein/agingdeveloper/commit/b45eecfecf2760814c7cbbe4a239afd958ec68f3))
+* wip ([e46fd92](https://github.com/richwklein/agingdeveloper/commit/e46fd9204708fbd55dff8c0490b8381d74d675dc))
+
+## 2.1.0 (2024-01-22)
+
+### Bug Fixes
+
+* implement the 404 page ([c9681e1](https://github.com/richwklein/agingdeveloper/commit/c9681e127a9fe9b058f70967d37d62fa1eda2c30))
+
+### Miscellaneous Changes
+
+* Bump the github-actions group with 1 update ([7964953](https://github.com/richwklein/agingdeveloper/commit/79649535dd509ba683aa5d5ae072d05d36c3bc92))
+* Tag on package version change ([c74d94f](https://github.com/richwklein/agingdeveloper/commit/c74d94f9a8cd370fe493aa4cb8c72048c61e0bf2))
+* try setting the token via env ([080832a](https://github.com/richwklein/agingdeveloper/commit/080832a95a191fa13345fa5ac0e9b4d1fcec45d5))
+* fix workflow ([ffa5332](https://github.com/richwklein/agingdeveloper/commit/ffa53324408d4baff9ed84d0520adf40fb8ad5d7))
+* Fix linting and run docs ([8ee86f3](https://github.com/richwklein/agingdeveloper/commit/8ee86f3cf62597ad46640efcd8f8916432e116c0))
+* still trying to get coverage to work ([750e92d](https://github.com/richwklein/agingdeveloper/commit/750e92dcc03ec64fad94d6e503e68a01190ddd0b))
+* [skip ci] Update the github actions to try and make them work ([b2c2269](https://github.com/richwklein/agingdeveloper/commit/b2c22691528373ad51dab959ec00b4df1d78c6b6))
+* Add offline support and tweak code coverage action ([65f3086](https://github.com/richwklein/agingdeveloper/commit/65f3086565bc7926f877f1fa32f9fdda7ac65034))
+* Include a code coverage action ([0cf33d1](https://github.com/richwklein/agingdeveloper/commit/0cf33d10083499d4b81a049c035a9bcf45bc3818))
+* Add a github action to bump the package version and tag a release ([b99bd12](https://github.com/richwklein/agingdeveloper/commit/b99bd126189877920c2f4809773b35470b8b5156))
+* Update the repo config ([f04c570](https://github.com/richwklein/agingdeveloper/commit/f04c570b3a6f58a4d234303cf85884ffe80f0e0c))
+* Remove netlify.toml ([4e075d8](https://github.com/richwklein/agingdeveloper/commit/4e075d89493ff1414690290869efc00bd298f5e9))
+* remove package lock and fix description ([11150c6](https://github.com/richwklein/agingdeveloper/commit/11150c63364aff27871af36cb667626e32926bfe))
+* tweak the code blocks for better support ([9f8b74e](https://github.com/richwklein/agingdeveloper/commit/9f8b74e39d0fcfc5d57f6463728185b077f8051a))
+* Add another test to make sure the component handles a string child ([19a34a8](https://github.com/richwklein/agingdeveloper/commit/19a34a8e1f0229b4d565ea4836d0c00a49e5cf43))
+* Replace the rendering of code blocks with the prism-react-renderer component ([8c4e53e](https://github.com/richwklein/agingdeveloper/commit/8c4e53e639b14d33662e38e6675476a8732fee92))
+* fix snapshots ([b2eb6bb](https://github.com/richwklein/agingdeveloper/commit/b2eb6bb3d7e52a2b06e646d9c78de8b1b4a189ef))
+* upgrade icon dependency and remove lock file ([2cf8ed6](https://github.com/richwklein/agingdeveloper/commit/2cf8ed6c1a5d457f0ceca3d20a53580621693fad))
+* Bump the npm_and_yarn group across 1 directories with 2 updates ([db1c20d](https://github.com/richwklein/agingdeveloper/commit/db1c20d31e94652133805f5f00520b798aeac879))
+* Bump @mui/material from 5.15.3 to 5.15.4 ([8b21e0d](https://github.com/richwklein/agingdeveloper/commit/8b21e0d082deb95d820d280a57428f74a4797b1f))
+* fix casing ([c28e19c](https://github.com/richwklein/agingdeveloper/commit/c28e19ca245ad6f2702009e28b5928ffcba6db9d))
+* Drop the slug property from the site json ([194be3e](https://github.com/richwklein/agingdeveloper/commit/194be3eaad7d195d8ce621c51c0c612c3d496eba))
+* fix bad formatting by eslint ([a7f2667](https://github.com/richwklein/agingdeveloper/commit/a7f2667f93e7ddd8bf8615757f006969f5fc1a68))
+* Switch from using yaml to json for data ([32ef727](https://github.com/richwklein/agingdeveloper/commit/32ef7274d1275e6a7e392ed996f8ca998350b570))
+* remove unused import ([e499afc](https://github.com/richwklein/agingdeveloper/commit/e499afc16cdfb091a5f074ab7ca38a9d0696f85c))
+* Move redirects to a separate file ([7e8152f](https://github.com/richwklein/agingdeveloper/commit/7e8152fc99e8450569ebb7c97cd737e8a3cdad76))
+* Enforce the fields in the article frontmatter and use custom resolvers for defaults ([e7dccfa](https://github.com/richwklein/agingdeveloper/commit/e7dccfab51dd867a0c6e5706a7d5c2727f33c513))
+* Fix misplaced image ([41a739d](https://github.com/richwklein/agingdeveloper/commit/41a739d5e000c64bb39b24ad475e8091cc752e42))
+* Bump @mui/material from 5.15.2 to 5.15.3 ([7b25451](https://github.com/richwklein/agingdeveloper/commit/7b254513d7ccced8ce484a881b394ab6d93e260c))
+* Bump @mui/icons-material from 5.15.2 to 5.15.3 ([1175407](https://github.com/richwklein/agingdeveloper/commit/11754079d9976650bc139fa58906f5a5a4119852))
+* Bump @testing-library/jest-dom from 6.1.6 to 6.2.0 ([0213959](https://github.com/richwklein/agingdeveloper/commit/021395927742b3a7e6e7612f30074f20a82c4753))
+* Move keybase file so it is served ([51648c3](https://github.com/richwklein/agingdeveloper/commit/51648c3b62dde7c999433927b45e473c0b465ba4))
+* get analytics working??? ([972be2e](https://github.com/richwklein/agingdeveloper/commit/972be2ea0abfa0e4431c9d1239661cd374860ad6))
+* Bump @mui/material from 5.14.18 to 5.15.2 ([a9acd82](https://github.com/richwklein/agingdeveloper/commit/a9acd8229d6a53047f59d8dbff1f2e8c60c1316b))
+* Bump @emotion/react from 11.11.1 to 11.11.3 ([138c825](https://github.com/richwklein/agingdeveloper/commit/138c825ad8ab1f022f1e80a77fcb88550cb31219))
+* Fix issue with twitter cards ([67eb738](https://github.com/richwklein/agingdeveloper/commit/67eb738173c57c2b04e229b501afeb164e32e9b8))
+* Bump @testing-library/jest-dom from 6.1.4 to 6.1.6 ([d5ce224](https://github.com/richwklein/agingdeveloper/commit/d5ce224e7ba6469cf631efbd8a639cf82a8de000))
+* Bump @mui/icons-material from 5.14.18 to 5.15.2 ([bb40ea4](https://github.com/richwklein/agingdeveloper/commit/bb40ea41526397ee2cd37c1ad535d337217b26d5))
+* tweaks for the newest article ([20a667d](https://github.com/richwklein/agingdeveloper/commit/20a667de99bc0cea707bd3e851f85e0658db9c54))
+* fix syntax highlighting ([e389d02](https://github.com/richwklein/agingdeveloper/commit/e389d0208226f240c3a62061749afdfccc9f10c7))
+* pluralize ([a229811](https://github.com/richwklein/agingdeveloper/commit/a229811b746da36ac09b89d89b8c40b07e16e368))
+* Rebuild article ([045119b](https://github.com/richwklein/agingdeveloper/commit/045119b15a30af8d22ec56ad379351411eac75d5))
+* Add back in sitemap support ([ef4bf61](https://github.com/richwklein/agingdeveloper/commit/ef4bf619dfccfec33703e0c41409bbb5d9be14b2))
+* Add docs ([20c47c3](https://github.com/richwklein/agingdeveloper/commit/20c47c3a0ccbdffd85d7fde8d7c2991de7cd6e5c))
+* Add manifest and favicon ([f3b4f88](https://github.com/richwklein/agingdeveloper/commit/f3b4f8868a092bd18e8be5e01aa8e43da931934a))
+* Add author index page ([12a903a](https://github.com/richwklein/agingdeveloper/commit/12a903afc633e51bd662c78a2ea2af8adb007269))
+* Fix redirect rule ([2eb20d6](https://github.com/richwklein/agingdeveloper/commit/2eb20d620abd32fd7dff0c792a2346ada389704f))
+* fix up the redirects ([8cf801d](https://github.com/richwklein/agingdeveloper/commit/8cf801d266160dbefd12c521e1110a05bd75eec5))
+* Set up build file and redirects ([a64938d](https://github.com/richwklein/agingdeveloper/commit/a64938d5a9746f3856e5d2b66a3a314b3ec7d6d8))
+* Add a template for rendering author pages ([4080327](https://github.com/richwklein/agingdeveloper/commit/40803279cb58acf53ae3bbf75a92fe387772543f))
+* Add a button to navigate back ([10d82d1](https://github.com/richwklein/agingdeveloper/commit/10d82d1dff333ce7d466757058b533088ccd04f9))
+* Add google analytics ([b85fe58](https://github.com/richwklein/agingdeveloper/commit/b85fe58a7e4f1bcf06a3acb814bc4e1780cbc999))
+* Add robots.txt ([15b899f](https://github.com/richwklein/agingdeveloper/commit/15b899f7a01319ec294fecb70426a70d8573d6e5))
+* Fix unit tests ([4946347](https://github.com/richwklein/agingdeveloper/commit/4946347f2f4d0045007c794944d8ae28287e7cdd))
+* Fix unused imports ([e28650b](https://github.com/richwklein/agingdeveloper/commit/e28650b645989a2cfea5dfaf9d76d6df21a26068))
+* Bump gatsby version and tweaks ([7b1dc45](https://github.com/richwklein/agingdeveloper/commit/7b1dc45a5c61aca6aecc59e5c2740e47e162d5aa))
+* Add SocialButtonBar tests ([5bf8082](https://github.com/richwklein/agingdeveloper/commit/5bf80827880c1bfc6bde682091199f7d918bff0e))
+* Add todo for tests ([66bc467](https://github.com/richwklein/agingdeveloper/commit/66bc4671b7fe6614cd1126228a835805a15fae8b))
+* fix console errors and sort exports ([df833b9](https://github.com/richwklein/agingdeveloper/commit/df833b92e7ded7bdeeac4cddff984cca3383a1b4))
+* Get archive pages working ([1004ad3](https://github.com/richwklein/agingdeveloper/commit/1004ad3fc7e27c4304267d3525669b8476ba1d98))
+* Bump dependencies ([04d76b2](https://github.com/richwklein/agingdeveloper/commit/04d76b2bb5264ddffd54968db43d37649282f0f7))
+* Get build fixed ([87e1213](https://github.com/richwklein/agingdeveloper/commit/87e12130a6db9ec0b1c0f21d43627ce602a81e5c))
+* change frontmatter field to be "published" instead of "date".  Continue adding SEO. ([39255a2](https://github.com/richwklein/agingdeveloper/commit/39255a20e469e53b17a685da196739a006616780))
+* Get documentation in a good spot and all current pages rendering. ([0db8045](https://github.com/richwklein/agingdeveloper/commit/0db8045f617e2bc909630c76d9e3296ee90cd175))
+* more docstrings ([75a46d8](https://github.com/richwklein/agingdeveloper/commit/75a46d8715608614b024d6fcf0945ade92174435))
+* Adding more docstrings and getting the tag breadcrumb to work ([e525fd6](https://github.com/richwklein/agingdeveloper/commit/e525fd6c384ac43e07d3495d60fb3ac0a2b8da7f))
+* Add title block docs ([b2866a4](https://github.com/richwklein/agingdeveloper/commit/b2866a4c7b32270444cf1e2caf3f55ee96b1936f))
+* Add docs and tests to DisplayLimit ([3bd09a6](https://github.com/richwklein/agingdeveloper/commit/3bd09a655fd6898ed367387692594929dfe39668))
+* working on tests ([85414d6](https://github.com/richwklein/agingdeveloper/commit/85414d65e560a8195367bd9e1f57ac12a0eb7000))
+* Additional docs ([ddc6e1a](https://github.com/richwklein/agingdeveloper/commit/ddc6e1a36876f85bccfe1ed73b1bce2b27d4f41c))
+* test fixes ([a243454](https://github.com/richwklein/agingdeveloper/commit/a2434541c007aa5a23da4a2d506d20d78c11e870))
+* Start adding jsdocs and improving code ([4df88f0](https://github.com/richwklein/agingdeveloper/commit/4df88f078ac5fd29d7173dddff680a109b83d29e))
+* Get queries working for all the pages ([d9d479a](https://github.com/richwklein/agingdeveloper/commit/d9d479a681842fe55a954c9d9e28d4a7841ff8e7))
+* fix build ([6e6537b](https://github.com/richwklein/agingdeveloper/commit/6e6537bde1ac857d381ff41401033b2cc90d59e4))
+* fix build ([0bb9a82](https://github.com/richwklein/agingdeveloper/commit/0bb9a82d5ea3afe4224aca368ffa3bd88a10a438))
+* Get full height body working ([680f90d](https://github.com/richwklein/agingdeveloper/commit/680f90dc2c9b1ac8628aa7e474656fad464e7ab5))
+* Move around components ([9446777](https://github.com/richwklein/agingdeveloper/commit/9446777d24acf5f73fd744b75ab05fa5accadfa6))
+* Add fonts ([c307643](https://github.com/richwklein/agingdeveloper/commit/c3076435a93c0ebe5dd2d9422d4ff88201717ed8))
+* Increase the number of articles on the front page ([3882661](https://github.com/richwklein/agingdeveloper/commit/3882661710d8c9c90c6f6cdec6e9787ebfe39f7a))
+* add formatting back to ci build ([ee1f759](https://github.com/richwklein/agingdeveloper/commit/ee1f75945a7c6bee3b8a1c4820e601acf10b90c5))
+* tweak some styles ([f5a38b9](https://github.com/richwklein/agingdeveloper/commit/f5a38b9750002ec28d17ce5dbf38752e1026df94))
+* Reduce the blur on the hero image ([b089757](https://github.com/richwklein/agingdeveloper/commit/b089757894e762587e411edf6baa61fbc2ff4bf4))
+* Add the rest of the content to the branch ([b52b34b](https://github.com/richwklein/agingdeveloper/commit/b52b34bb6df04eec65fa1c8663f94654a79f9873))
+* fix author slug ([d734bd0](https://github.com/richwklein/agingdeveloper/commit/d734bd01af15b0af57abacd958c1c7b659437552))
+* Add TODOs ([b9769b7](https://github.com/richwklein/agingdeveloper/commit/b9769b79ebe60e744cfc50b6fc33bb2810646eec))
+* Get a hero block added to the home page ([e3e124d](https://github.com/richwklein/agingdeveloper/commit/e3e124dc49f07821f34072549cb4505832a434be))
+* Add time to read to the article template ([ccbc9e7](https://github.com/richwklein/agingdeveloper/commit/ccbc9e726071919e8455c3eb9eae5048b059afa3))
+* Get the avatar on the top bar ([7430995](https://github.com/richwklein/agingdeveloper/commit/74309955a4898cfbd50271cb2ed4305b8819fce1))
+* Improve TagBar and tests ([8083099](https://github.com/richwklein/agingdeveloper/commit/8083099ace617807face7b7025264a709d533bc3))
+* Try and get the ci working ([f2733c1](https://github.com/richwklein/agingdeveloper/commit/f2733c1a6e1b1e29db9b02f96fd7c058332a14ef))
+* Add another page ([aebed87](https://github.com/richwklein/agingdeveloper/commit/aebed8721b758abfab0659315d224be545d08930))
+* Add tagbar support ([2cd0e79](https://github.com/richwklein/agingdeveloper/commit/2cd0e796efa0c96cecff283eb56d37c4217f3904))
+* Add featured image support ([b537bc9](https://github.com/richwklein/agingdeveloper/commit/b537bc96ed0fe9d76e0e5f7d3f5253de99679dc2))
+* Move the title block to a component ([d06f47b](https://github.com/richwklein/agingdeveloper/commit/d06f47beece7abeff313f7cae6d9c050e69eecf1))
+* Article By Line ([d308c4a](https://github.com/richwklein/agingdeveloper/commit/d308c4a8e67b364d12d2c60833e8ce7253634d56))
+* more progress ([ae616a3](https://github.com/richwklein/agingdeveloper/commit/ae616a3e06be528f330d2b8479e2364fc8e2799d))
+* Adding tests ([59a3b86](https://github.com/richwklein/agingdeveloper/commit/59a3b8604f42395cf5014815aa5e8839fea63d04))
+* Switch basic testing to be snapshots ([c9cb1d4](https://github.com/richwklein/agingdeveloper/commit/c9cb1d41a8c58a1262c97e2be0a88400f6cf8401))
+* Start unit testing ([c94498a](https://github.com/richwklein/agingdeveloper/commit/c94498a765d0ce1bf23ecfe562a4610382bad35d))
+* initial work ([d122750](https://github.com/richwklein/agingdeveloper/commit/d122750869a75a4f430f32874ff62ddd8a7de9cc))
+* initial work ([a91123e](https://github.com/richwklein/agingdeveloper/commit/a91123e1bcecf8cd0852a9f624d6fb77cf24b5e1))
+* Starting over ([1d8e81d](https://github.com/richwklein/agingdeveloper/commit/1d8e81d2912bbd94c830851cdb977074194a6911))
+* Attempt to update node version used in build ([884771d](https://github.com/richwklein/agingdeveloper/commit/884771d342bd9b9dee18d25983081de696986451))
+* Bump eslint from 7.32.0 to 8.36.0 ([c2d6c27](https://github.com/richwklein/agingdeveloper/commit/c2d6c27db1b2d293803badc8abb6fa5f66ae13bc))
+* ignore cache directory and increase dependabot ([f876237](https://github.com/richwklein/agingdeveloper/commit/f876237828f73106af51477060319163a66ef7e4))
+* Bump gatsby-remark-images from 3.11.1 to 7.7.0 ([7116103](https://github.com/richwklein/agingdeveloper/commit/71161031ffe0a7dc24c1a2e56555432f9bb84e57))
+* Bump eslint from 7.32.0 to 8.36.0 ([d9f8b3f](https://github.com/richwklein/agingdeveloper/commit/d9f8b3f8641bbd8f48315bda06de92a18ceb73ee))
+* Bump gatsby-remark-prismjs from 3.13.0 to 7.7.0 ([bb1801b](https://github.com/richwklein/agingdeveloper/commit/bb1801b51414652382a3e9c42bdc7ef25a4d34bd))
+* Bump eslint-config-react-app from 6.0.0 to 7.0.1 ([f808db9](https://github.com/richwklein/agingdeveloper/commit/f808db93c9d04b317fb6fd36075a4dfdd9440edf))
+* Fix security mdx vulnerability ([1c63827](https://github.com/richwklein/agingdeveloper/commit/1c63827439f28fad63e4185377070a9620bab691))
+* Update index.md ([302193b](https://github.com/richwklein/agingdeveloper/commit/302193b95e5d9d7166a1358da86f457a62e7db4c))
+* Finish the article ([2d51803](https://github.com/richwklein/agingdeveloper/commit/2d51803c41eb68278df92eff162cb2eb48dde914))
+* article tweaks ([bc6292c](https://github.com/richwklein/agingdeveloper/commit/bc6292c1d0e35d6f3857b57e7361e0dfde248ae2))
+* disney post ([75a2701](https://github.com/richwklein/agingdeveloper/commit/75a270153024f3f75d6d39a0c1b59bdbe4f2b9a8))
+* Bump react from 17.0.2 to 18.1.0 ([59beabd](https://github.com/richwklein/agingdeveloper/commit/59beabd1aef9b5be0e32347f511c6c58b0ea7538))
+* drop versioning header ([5759624](https://github.com/richwklein/agingdeveloper/commit/5759624c1bc158c471dfe45f198d1dc8e5d04c28))
+* fixing ([af7dcf0](https://github.com/richwklein/agingdeveloper/commit/af7dcf0508b784a0080de7ad0c8243e5ca4352c5))
+* fix deps ([6a3e6d2](https://github.com/richwklein/agingdeveloper/commit/6a3e6d21038d442158a3696362958012251e4c24))
+* try and fix deps ([551c887](https://github.com/richwklein/agingdeveloper/commit/551c8873cc5218cb5cca85d0f936450bcdef6fdb))
+* force legacy dependency resolution ([0582865](https://github.com/richwklein/agingdeveloper/commit/058286558bfb7d3de58a696be20b4e8d9be3d3a3))
+* tweaking versions ([f5533cc](https://github.com/richwklein/agingdeveloper/commit/f5533ccbc61d3e8d88c0a91cdf68872c0d0ca731))
+* try newer version of node ([54aa22b](https://github.com/richwklein/agingdeveloper/commit/54aa22bf52e97d4b7760cdf9a524f3e78ba7580e))
+* try default node and ruby ([b5c897f](https://github.com/richwklein/agingdeveloper/commit/b5c897f7e5c21cd0341479fa35fb80d57471abc3))
+* New Article ([d5970e6](https://github.com/richwklein/agingdeveloper/commit/d5970e682931e06ae5ae0165eb5a08f99a81a7db))
+* fix captialization ([922118e](https://github.com/richwklein/agingdeveloper/commit/922118edf6a4ac49d531796a13edbb95acc7c5d6))
+* tweak tense ([2c7680a](https://github.com/richwklein/agingdeveloper/commit/2c7680a2f852dab40a06b0dd0f0b0ec8c0598e26))
+* RSS Article ([b17c1cb](https://github.com/richwklein/agingdeveloper/commit/b17c1cb5f95659b569ece80eb575c27b16e9da9e))
+* Remove ignores ([369ef58](https://github.com/richwklein/agingdeveloper/commit/369ef58da2787b1f58f064ef339deb2f3918aa0a))
+* start on article ([237a64e](https://github.com/richwklein/agingdeveloper/commit/237a64e5066b8547ee85788a8928d495f2d6b0a0))
+* Upgrade to GitHub-native Dependabot ([ae596dd](https://github.com/richwklein/agingdeveloper/commit/ae596dd8f8f19b2c675b7beb78bdec1d917e6fa1))
+* Opt the website out of floc ([7189514](https://github.com/richwklein/agingdeveloper/commit/7189514f73d0fea569b31aef1f78245e8b075c08))
+* Make a PWA and add favicons ([98360af](https://github.com/richwklein/agingdeveloper/commit/98360af212fad92f504efca2c50125630efeb041))
+* upgrade minor versions ([720bbf7](https://github.com/richwklein/agingdeveloper/commit/720bbf7f5a8be2d8b7c25d44147b62288ade170d))
+* Add html to the rss feed ([1381c62](https://github.com/richwklein/agingdeveloper/commit/1381c628fff2e674e5a84345bd21bb8617cb0b17))
+* Update Dependencies ([3a080b0](https://github.com/richwklein/agingdeveloper/commit/3a080b0b36c4555080c2c34ef68cb45e6636d8a0))
+* Article on commit signing ([0d6d270](https://github.com/richwklein/agingdeveloper/commit/0d6d27092377ca425ea76ab20b90b2d74942b852))
+* Git Commit Signing Article ([791d3ff](https://github.com/richwklein/agingdeveloper/commit/791d3ff1408a73d6f3b7ffb3a76158f106f08928))
+* wip ([7698690](https://github.com/richwklein/agingdeveloper/commit/76986902ed954fcbf20ef922ece4ea88d5036229))
+* Fix publish date ([2772d2a](https://github.com/richwklein/agingdeveloper/commit/2772d2a887ee9d98b27a7631d9c3475b54a62551))
+* Article on virtual choir ([9bd913e](https://github.com/richwklein/agingdeveloper/commit/9bd913e624ba85438314894e437c59d60477824a))
+* Update packages to newest versions ([b01bf50](https://github.com/richwklein/agingdeveloper/commit/b01bf50dc66d568723f6d0bed883692519f567ad))
+* Bump eslint-config-react-app from 5.2.1 to 6.0.0 ([9a517c4](https://github.com/richwklein/agingdeveloper/commit/9a517c40e25b712135ab082b0c38030a977bcc13))
+* drop one of the links to other articles ([c76f6d8](https://github.com/richwklein/agingdeveloper/commit/c76f6d886875630336455b43ac6b9bb68199ebd1))
+* Samsung article with image tweaks ([1cce5d0](https://github.com/richwklein/agingdeveloper/commit/1cce5d0755377389d9f472f5655fe2acd86fdf94))
+* install npm globally ([aab2b65](https://github.com/richwklein/agingdeveloper/commit/aab2b6562649ca012153425f4d7282fee295e111))
+* Tweak the material-ui ([725769e](https://github.com/richwklein/agingdeveloper/commit/725769ef037168d67c33a9e7a042af36169c4e77))
+* Basic feed support without actual items yet ([7cd28eb](https://github.com/richwklein/agingdeveloper/commit/7cd28ebdd3995b8c4b63891b125453ba6e83f2b4))
+* Use more promises to parallelize more ([e1c8ef6](https://github.com/richwklein/agingdeveloper/commit/e1c8ef68ddf9eb47c60625c485a1740ef5148161))
+* remove content hashes from build ([9e06076](https://github.com/richwklein/agingdeveloper/commit/9e060764e699312585806f158a06b4713d8505d0))
+* rearrange plugin list ([671f99c](https://github.com/richwklein/agingdeveloper/commit/671f99c94cf897ad198fbcdcb5b28b7c56caa50f))
+* Enable build caching and switch to parallel page generation ([41b3cd4](https://github.com/richwklein/agingdeveloper/commit/41b3cd4718308cbb20439dfa8d112cb3ed5eb0ce))
+* fix typo ([0b997a4](https://github.com/richwklein/agingdeveloper/commit/0b997a4f2c210e6dc3329ea93c186637b6fab326))
+* Update article.js ([1956c26](https://github.com/richwklein/agingdeveloper/commit/1956c262476c533ad5cc9e28a9f1dcb9b239b864))
+* Update index.md ([fe7d36b](https://github.com/richwklein/agingdeveloper/commit/fe7d36b80a8b20e89c858983ee4044a4dfc0e52c))
+* new post on why aging developer ([0711f75](https://github.com/richwklein/agingdeveloper/commit/0711f7544c2081b104c911ebad6d703e13b32281))
+* fix description quoting on article ([219f3f9](https://github.com/richwklein/agingdeveloper/commit/219f3f9bb3e7316259528f695213d184bf3df900))
+* Add a description to the frontmatter for seo ([d9bed27](https://github.com/richwklein/agingdeveloper/commit/d9bed27972acaba5024c84c124c1b524ab8bed93))
+* ignore long line ([50c7a1f](https://github.com/richwklein/agingdeveloper/commit/50c7a1f6937e7f53c9d7f5a792c4bb4542435a49))
+* Create a custom 404 page ([204cc25](https://github.com/richwklein/agingdeveloper/commit/204cc255adc76a11a2d1777f8d538fbd20dd816c))
+* tweak the nav drawer ([4cb8400](https://github.com/richwklein/agingdeveloper/commit/4cb8400954c3213881f3e4dc2e441f3ccb56883e))
+* Fix badge causing mobile overflow issues ([2c32c67](https://github.com/richwklein/agingdeveloper/commit/2c32c67123745c2b5742b819faf081a38e145a7c))
+* New article on the author pages ([98e5ef4](https://github.com/richwklein/agingdeveloper/commit/98e5ef4abad0a42b78eab3e967690164188f556d))
+* Remove extra fragment ([16d37cd](https://github.com/richwklein/agingdeveloper/commit/16d37cd989dd0baf1e64200f117fa24ec798e07b))
+* Split tags back out ([d26f95d](https://github.com/richwklein/agingdeveloper/commit/d26f95dcd0656061b564e201f7506d79623d65e3))
+* tweak banner ([8a88049](https://github.com/richwklein/agingdeveloper/commit/8a880494d98a2a2c4a891271c5b006e0c63da7d2))
+* Finish landing the author pages ([af1d399](https://github.com/richwklein/agingdeveloper/commit/af1d3996bf513a23f7db05d16a56cbd2427c1fac))
+* Land most of the author pages work ([626131c](https://github.com/richwklein/agingdeveloper/commit/626131ce7b0f2356a9216d842416b17b178a0c4d))
+* tweaks on the way to landing author pages ([4e8beb6](https://github.com/richwklein/agingdeveloper/commit/4e8beb6e649e9f8e0a1dcee339daf70662cc7636))
+* tweak spacing more and add frontmatter settings ([bef98b6](https://github.com/richwklein/agingdeveloper/commit/bef98b6b6c94a0d5c9da4fc3d0567a40333ffb5b))
+* Adjust padding for responsive layout ([f87c9e4](https://github.com/richwklein/agingdeveloper/commit/f87c9e4525f888c5b527f142ecfc1dd60557c7dc))
+* Add new badge for articles newer than 14 days ([f3f3723](https://github.com/richwklein/agingdeveloper/commit/f3f3723de73d56e221c8008be613f1abac87ba36))
+* Add home to nav drawer ([a036dbb](https://github.com/richwklein/agingdeveloper/commit/a036dbbbd50e5b640a1c6ebe6d3d66247e438bd4))
+* Get an initial articles page done ([58200e6](https://github.com/richwklein/agingdeveloper/commit/58200e6aa7e03c608d2fcf2e7ad78ac6f085b2f4))
+* Style code using prismjs ([a499c6e](https://github.com/richwklein/agingdeveloper/commit/a499c6e727f7c10b0d029f0eb1fba249f0b8e0cf))
+* generalize the gridlist and button grids ([351b55a](https://github.com/richwklein/agingdeveloper/commit/351b55a9b06b1b4aa26e562e8e6271cb5e8734dc))
+* remove topbar padding ([82afb3e](https://github.com/richwklein/agingdeveloper/commit/82afb3eac770ba0e914c06bc80bab2c631fa782f))
+* drop breadcrumbs and reorganize ([df75fa9](https://github.com/richwklein/agingdeveloper/commit/df75fa979137231842786c68573a774e98f251aa))
+* fix up some grammer issues ([df47f4d](https://github.com/richwklein/agingdeveloper/commit/df47f4d41c4cbf59db7d6421dc5a25cd9b2cfb5f))
+* tweak wording ([d523cc5](https://github.com/richwklein/agingdeveloper/commit/d523cc55cd31a2140f1fd90c2dbbf930078fcea5))
+* tweak the last few paragraphs ([27ea239](https://github.com/richwklein/agingdeveloper/commit/27ea23904a9b1699f935f2cf37e2412296d4c6aa))
+* fix typo ([7a892be](https://github.com/richwklein/agingdeveloper/commit/7a892be06e9ae61f8260af67b86e808fbd9863e3))
+* fix typo ([d2d44c1](https://github.com/richwklein/agingdeveloper/commit/d2d44c1c95d664bc481655df6cf2123481bd1ce7))
+* Add post aboue default http config ([6e035e8](https://github.com/richwklein/agingdeveloper/commit/6e035e89c4d2db54ddd3616e7d34b8925ff04c40))
+* change how we style disabled links and fix lint issues ([48026f5](https://github.com/richwklein/agingdeveloper/commit/48026f5b20f2dd46ad8ff192406ed4a7061e454f))
+* Article on setting up a custom domain in netlify ([a8f8386](https://github.com/richwklein/agingdeveloper/commit/a8f8386c8fe6c24854f283596bccea30300c8fb8))
+* tweak the breadcrumb styling ([80c2977](https://github.com/richwklein/agingdeveloper/commit/80c2977310455020b2bb60019f88adb20cb9e187))
+* Add the category page and tweak the tag pages ([dc1952b](https://github.com/richwklein/agingdeveloper/commit/dc1952b57e7f2ff4122febf674df70a5523ca04c))
+* Uppercase tags ([9d58ab5](https://github.com/richwklein/agingdeveloper/commit/9d58ab511d1a2cc0ca9193153195a4252605a8cb))
+* Add plugin to ping search providers on publish ([6158f79](https://github.com/richwklein/agingdeveloper/commit/6158f79c5a42fd72827185fe5f7c2d4df4c5ed4f))
+* tweak tag page ([581832f](https://github.com/richwklein/agingdeveloper/commit/581832f203d4396e28d245a259030d6a6462328f))
+* Add the tag pages ([afe144d](https://github.com/richwklein/agingdeveloper/commit/afe144d3f478d70a3ea165a7aa80bab44779a9d0))
+* Trying to get the urls correct ([34d4891](https://github.com/richwklein/agingdeveloper/commit/34d489114e929a267c8d8af6c3f8e47faa2dde1f))
+* fix line length ([498f3c9](https://github.com/richwklein/agingdeveloper/commit/498f3c9e65dc83273434426201a572941aaa3dc4))
+* fix previous/next buttons ([ddb2ce3](https://github.com/richwklein/agingdeveloper/commit/ddb2ce3455ddef90bd3d273775bec5fdab190bb3))
+* fix breadcrumb ([b65ddf8](https://github.com/richwklein/agingdeveloper/commit/b65ddf8a298e2f56311ebd42fcaf602b420bc0d1))
+* fix link in false starts article ([fcb310d](https://github.com/richwklein/agingdeveloper/commit/fcb310d8bee2b5395d14382052c3ebe3f448b1c3))
+* Fix breadcrumb path ([fa26b24](https://github.com/richwklein/agingdeveloper/commit/fa26b241e190812a42a293d068a396780fd3af20))
+* Fix reditect ([29d7980](https://github.com/richwklein/agingdeveloper/commit/29d798077dc3846f3aa3199c43ac109632d592da))
+* Fix output directory ([8ee488a](https://github.com/richwklein/agingdeveloper/commit/8ee488a44ad89e9bad0770914696b3cf5c3d71c4))
+* Add file based build ([cfd3f35](https://github.com/richwklein/agingdeveloper/commit/cfd3f354d11a61d53563d9349d5e0225a5fed7b8))
+* Move the article prefix and switch to file based build ([09a5be9](https://github.com/richwklein/agingdeveloper/commit/09a5be912c0e4c777a9dfc2d911ec6a8a9d9fe7a))
+* Add breadcrumb ([5f7bb48](https://github.com/richwklein/agingdeveloper/commit/5f7bb481718d5d6e8101a55d124d16f0b930f303))
+* Add comments and tweak article layout ([29ce5f3](https://github.com/richwklein/agingdeveloper/commit/29ce5f374ab0cc834b93c08004c88e7bbc9745c0))
+* embed path prefix in article url ([91d2e3e](https://github.com/richwklein/agingdeveloper/commit/91d2e3e23e5c1b24e66cc27935482ec4c327c6f9))
+* Reorder nav bar ([859529a](https://github.com/richwklein/agingdeveloper/commit/859529a3fc1640f88e4aa1b57614739f44aecb63))
+* Add view all button and move articles to article path prefix ([e238260](https://github.com/richwklein/agingdeveloper/commit/e238260338a53651513d3b64d6d590080af2a55c))
+* Fix image sizes on article page on mobile ([d742412](https://github.com/richwklein/agingdeveloper/commit/d742412a143bbd51ae9745f8099f34f63bc09fe6))
+* Land SEO headers ([cf00e88](https://github.com/richwklein/agingdeveloper/commit/cf00e885d9d64ffafd35d80bf17062144897d6af))
+* Issue #27 explain content location ([0579bed](https://github.com/richwklein/agingdeveloper/commit/0579bedfe1de57d9bcd0d6c5e303d24629570d58))
+* Add smoe more lint rules ([5926020](https://github.com/richwklein/agingdeveloper/commit/59260203fd2bad758ce58df5cd981d60b10c4d7c))
+* Adding vscode settings to the workspace ([069c2cb](https://github.com/richwklein/agingdeveloper/commit/069c2cb6e6f483ffd6e4d5a25797fe104142b725))
+* Specifying a ci build ([4293bcb](https://github.com/richwklein/agingdeveloper/commit/4293bcb96c0ec190afa83557392fb597ec9a302f))
+* Specifying a ci build ([43bc710](https://github.com/richwklein/agingdeveloper/commit/43bc7106e53a369b1a78f6a1a0967c67a3d8921d))
+* Update false-start.md ([c0f85db](https://github.com/richwklein/agingdeveloper/commit/c0f85db41c68b32214d9d8a70e49e31ca86ef485))
+* Tweak the avatar display ([dae3745](https://github.com/richwklein/agingdeveloper/commit/dae3745ad0607e22eb6f4533d908fd7cdcd34400))
+* Formatting fixes ([4302530](https://github.com/richwklein/agingdeveloper/commit/4302530b04e510104c25eee6fe1058feedd9fe78))
+* Formatting fixes ([b2bc23f](https://github.com/richwklein/agingdeveloper/commit/b2bc23f4491e136f00a9425c44c5bb9882d38e50))
+* test ([5b8b7a0](https://github.com/richwklein/agingdeveloper/commit/5b8b7a05568810be5d90e33e57cbef26bf6d0561))
+* Formatting fixes ([1e6bd4e](https://github.com/richwklein/agingdeveloper/commit/1e6bd4e724046f7dc75f4054065dd679fa8bbc96))
+* Fix eslint formatting ([82e89e6](https://github.com/richwklein/agingdeveloper/commit/82e89e64ef029e8f66ade6ff49d34ac0d81e5da3))
+* Fix formatting based on eslint ([83c5011](https://github.com/richwklein/agingdeveloper/commit/83c501145b3726fb381daa4f91d732a71f10fca9))
+* switch to using eslint instead of prettier and use the google styles ([1931048](https://github.com/richwklein/agingdeveloper/commit/1931048836ecd63cd665ef991d3f23eb009c3918))
+* Switch from prettier to eslint and use google's rules ([271e003](https://github.com/richwklein/agingdeveloper/commit/271e0031a4053ecad30bc246c752790cfdb69f79))
+* fix index title ([6e7a808](https://github.com/richwklein/agingdeveloper/commit/6e7a808d2e95ab60374f3c1373225df9fec88392))
+* Second article with fixes for image sizes and titles ([2bfb01c](https://github.com/richwklein/agingdeveloper/commit/2bfb01cdd5ce3ff0b00f57dba30f0a0884a91236))
+* Make components as standalone as possible and update the theme ([9a908cc](https://github.com/richwklein/agingdeveloper/commit/9a908cc20df2b3d2416516378cf9cd2b68cf4e20))
+* blah ([bf1c0f8](https://github.com/richwklein/agingdeveloper/commit/bf1c0f88473b26f8215dc68b9e7a1575d3084416))
+* More work on the author page ([1190ae5](https://github.com/richwklein/agingdeveloper/commit/1190ae50453bd047473af75c9e1ac708419c1acf))
+* Moving scroll logic into layout ([1ecc892](https://github.com/richwklein/agingdeveloper/commit/1ecc892dbf50e218126afccffd7b47ef9126eb61))
+* Moving scroll logic within layout ([332b0f8](https://github.com/richwklein/agingdeveloper/commit/332b0f8a686bfcd40fd99a721514dbce3c413688))
+* Moving scroll logic into layout ([f72e8e5](https://github.com/richwklein/agingdeveloper/commit/f72e8e560bce8604643bf7cb348ae76643b20ef1))
+* Moving scroll logic into layout component ([9c6d6ce](https://github.com/richwklein/agingdeveloper/commit/9c6d6ce16fe97deda23982eaf3d62f2443d65d66))
+* Move scroll logic into layout ([5105737](https://github.com/richwklein/agingdeveloper/commit/510573784cb400cb9c192fb6e4c29f011a0612a6))
+* Move scrolling into layout and fix ([5524430](https://github.com/richwklein/agingdeveloper/commit/5524430adf7d3009b835752eafa57a9aeba8211e))
+* Fix scrolling to top ([7193b80](https://github.com/richwklein/agingdeveloper/commit/7193b80a12e0dfda675d89a0b333fc12a19faeeb))
+* Start getting author setup ([95a9b5b](https://github.com/richwklein/agingdeveloper/commit/95a9b5bdcbb36bc196680d306cd38a951a8491b5))
+* add link to image ([ac22e73](https://github.com/richwklein/agingdeveloper/commit/ac22e73a0e3df0edf607742ef1392d1d0c5f23a6))
+* Change date format on article card ([5259af6](https://github.com/richwklein/agingdeveloper/commit/5259af6a07425af61d83cd48752c89c1688cb909))
+* Darken the text in the banner ([a7da6bf](https://github.com/richwklein/agingdeveloper/commit/a7da6bfbe0de08b7e02c3e10c0f5de24ef7fa86e))
+* Change the grey color ([8dae2ce](https://github.com/richwklein/agingdeveloper/commit/8dae2ce25f518b23407f84c15b5261b0f087e6f8))
+* Change grid spacing on banner ([f623bdd](https://github.com/richwklein/agingdeveloper/commit/f623bddf56962be9b1039b418dcb484cc4ca6fd8))
+* Get rough draft of home done ([cbeeba1](https://github.com/richwklein/agingdeveloper/commit/cbeeba197f4dcd690f51429756bae94625f7b244))
+* Update intro.md ([11ee501](https://github.com/richwklein/agingdeveloper/commit/11ee501ce7f814dfcb97018239f524db6e1a9c4c))
+* Update intro.md ([2627012](https://github.com/richwklein/agingdeveloper/commit/26270128666d37170445e37ea9e84989b6edb44d))
+* Add a colon to the warning ([781b8ab](https://github.com/richwklein/agingdeveloper/commit/781b8ab3bbe40acc50c3a42087f07b7a1cc3025b))
+* Update gatsby-node.js ([edb34cc](https://github.com/richwklein/agingdeveloper/commit/edb34cc132a2922493c5427da30cec5d5aa684fd))
+* update the intro post ([6a53bb7](https://github.com/richwklein/agingdeveloper/commit/6a53bb75dab58b308ec902ad258cb25967ba9813))
+* change the file name and url ([c604698](https://github.com/richwklein/agingdeveloper/commit/c6046981ad40a5cb4368762d88b880f9ce165804))
+* Get the first post in the books ([6c4c83a](https://github.com/richwklein/agingdeveloper/commit/6c4c83a2c35fe6950514b09bb035c9b62dc1567b))
+* Get article pages working ([2b363a6](https://github.com/richwklein/agingdeveloper/commit/2b363a67b9ea55401271e981bc74c1207178ec38))
+* Get the footer working ([1d45d9e](https://github.com/richwklein/agingdeveloper/commit/1d45d9e1bdc3da48dc4064294beb3a799ba00da9))
+* Add site navigation ([a0922ba](https://github.com/richwklein/agingdeveloper/commit/a0922ba8f48799a2849950ae9660e81d45100e2f))
+* Add keybase signature to show site ownership ([aedcdba](https://github.com/richwklein/agingdeveloper/commit/aedcdba8db8a5ddc50b50a9f5de47c156832276a))
+* Use a close button for the nav drawer ([c40400f](https://github.com/richwklein/agingdeveloper/commit/c40400f0333809c853646d7312d806a51d289975))
+* wip ([75b9d12](https://github.com/richwklein/agingdeveloper/commit/75b9d12f2494e5d36bb2cd2fdcd730340e0aa267))
+* set the typography and prefetch google fonts ([08bb726](https://github.com/richwklein/agingdeveloper/commit/08bb726b2344a995d96ad909c4cf4a254e4aa40c))
+* fix fousc ([5add831](https://github.com/richwklein/agingdeveloper/commit/5add8310f04176a73b16714abaff84e587bb9127))
+* tweak readme license info ([dfe545a](https://github.com/richwklein/agingdeveloper/commit/dfe545ab2805e6bf7170fe4b65631d3d830b4d08))
+* tweak readme ([404d26f](https://github.com/richwklein/agingdeveloper/commit/404d26f43f274292e9171e51e6ebaad2c19b5214))
+* Start landing where I'm at ([592c296](https://github.com/richwklein/agingdeveloper/commit/592c296a9cec21c8401507d418ff517de955aeb6))
+* Get the footer back in ([a01c7f1](https://github.com/richwklein/agingdeveloper/commit/a01c7f1608d6fe6545143bfe3e107575d0de1ec6))
+* cleanup ([e638024](https://github.com/richwklein/agingdeveloper/commit/e638024fea9d90e9a75e9f6a688c6542eb77875e))
+* ignore the package-lock file ([bb3af09](https://github.com/richwklein/agingdeveloper/commit/bb3af0985bb2a5e230596dd7a9299026b81ea1a6))
+* do not commit package-lock ([778897a](https://github.com/richwklein/agingdeveloper/commit/778897a7d7d421e849dcf33e6210df344164c0b1))
+* Trying to get a working build ([fbf0e7e](https://github.com/richwklein/agingdeveloper/commit/fbf0e7e001c5f16d71abbd1bb1ca3dedee155888))
+* still building ([14657c4](https://github.com/richwklein/agingdeveloper/commit/14657c4ac49a98c544e0832dcf5143749ed3e5f8))
+* find the footer ([07d0ac8](https://github.com/richwklein/agingdeveloper/commit/07d0ac8adac2f458c641bb0c1bdbf37fae53e62c))
+* Building ([12932d1](https://github.com/richwklein/agingdeveloper/commit/12932d1a25d910f3ed6b88c73bc37db799bb49e4))
+* Get netlify build working again ([e914aaf](https://github.com/richwklein/agingdeveloper/commit/e914aaf943cb90e23607c802b72c7a2377b8b0d3))
+* Trying to get builds working ([f633dd8](https://github.com/richwklein/agingdeveloper/commit/f633dd8ddc18d52db486034ca2560dbd033e48ff))
+* landing material design change ([2ac73a7](https://github.com/richwklein/agingdeveloper/commit/2ac73a711033f3a8fd5089d8c45917948c231dcf))
+* fix ssr ([434577f](https://github.com/richwklein/agingdeveloper/commit/434577fed2be7d1fd1d566bcbe5e8e2ccef8c91d))
+* Get theme colors set ([0becb1e](https://github.com/richwklein/agingdeveloper/commit/0becb1e77fde0a349deb8efee5210eebb55bb5b5))
+* commit the package-lock.json ([1bfe74b](https://github.com/richwklein/agingdeveloper/commit/1bfe74b4953053ae115874e468b669512115069b))
+* setup browser and ssr ([6ae685f](https://github.com/richwklein/agingdeveloper/commit/6ae685f3dedf445c5b681a0cf38d1635e793b05d))
+* Update the readme and remove the old mocks ([e677c2b](https://github.com/richwklein/agingdeveloper/commit/e677c2b4a5f16a492c59610ced1389dd7d9ce262))
+* Basic layout in place ([82a1343](https://github.com/richwklein/agingdeveloper/commit/82a1343151b6823d7f9236e49c8c3053ba9221a3))
+* Layout fixes ([d3fdd97](https://github.com/richwklein/agingdeveloper/commit/d3fdd972c5dc97881f4e616569968e2ab0fce713))
+* fix up make file ([a59f796](https://github.com/richwklein/agingdeveloper/commit/a59f7968a8e18f7d76885767835de6776f02b4fb))
+* netlify is still throwing errors ([116730a](https://github.com/richwklein/agingdeveloper/commit/116730aebb3577f046bf0626bd8be6c423ff27d0))
+* still trying to get it working ([264a59e](https://github.com/richwklein/agingdeveloper/commit/264a59e41cbea1556cacca322ec9b47ec2c34018))
+* Fix up the make files ([8ed9463](https://github.com/richwklein/agingdeveloper/commit/8ed9463c05bafc7416b60a85fb621fc802745aa5))
+* enable incremental builds ([c3d70d9](https://github.com/richwklein/agingdeveloper/commit/c3d70d9383592f333b7afba75f4513ec338eecc8))
+* Bump prettier from 2.0.4 to 2.0.5 ([4d54195](https://github.com/richwklein/agingdeveloper/commit/4d54195ce9e2cc42a789109e0f2b0247e68ad0fe))
+* Bump prettier from 2.0.3 to 2.0.4 ([14693b6](https://github.com/richwklein/agingdeveloper/commit/14693b606ac9ccd5f7258da8bc951553135def1a))
+* Bump prettier from 2.0.2 to 2.0.3 ([ee0c52a](https://github.com/richwklein/agingdeveloper/commit/ee0c52afe12bafe005a39b2115985b9900ece49d))
+* Bump prettier from 2.0.1 to 2.0.2 ([f922046](https://github.com/richwklein/agingdeveloper/commit/f9220463a1a0d7567d625c053eb3bc2f050bce02))
+* Bump prettier from 1.19.1 to 2.0.1 ([c52f0cd](https://github.com/richwklein/agingdeveloper/commit/c52f0cdb5b48483f09ca766605a94b9941c1cac8))
+* Add a markdown file to fix build ([fc900ed](https://github.com/richwklein/agingdeveloper/commit/fc900edd6d9deec721352f631600897621e489e1))
+* Updated layout ([12b020a](https://github.com/richwklein/agingdeveloper/commit/12b020a15a80d59a2109b39ea9f19ed3372b8922))
+* Update the styling to improve it. ([a04dcd8](https://github.com/richwklein/agingdeveloper/commit/a04dcd81a62841e53304c15648568e2b4793a46f))
+* Add a 404 page ([884c3cc](https://github.com/richwklein/agingdeveloper/commit/884c3ccb23e135d07ae4356e7f453362001a9d46))
+* Remove adsense ([55ab42d](https://github.com/richwklein/agingdeveloper/commit/55ab42d0494aae87a07ed0e66f9e060195f40271))
+* Set up analytics and ads ([35fcc90](https://github.com/richwklein/agingdeveloper/commit/35fcc90a68f3563d24670e4d122aa65a7fc5adfa))
+* fix robots.txt ([7634dae](https://github.com/richwklein/agingdeveloper/commit/7634daecb92eb908ed507fae6879910737f4064b))
+* fix robots.txt ([5a5f3b0](https://github.com/richwklein/agingdeveloper/commit/5a5f3b0a5a8e0fbd81decb9874ab7cfa0f589f5f))
+* fix robots.txt ([175365c](https://github.com/richwklein/agingdeveloper/commit/175365cc13a62b0439aa009706c014926305d2a9))
+* Add site navigation ([79a2053](https://github.com/richwklein/agingdeveloper/commit/79a2053da029009e05f29fc51de7e70618562b2b))
+* Fix makefile and simplfy gatsby-config ([ce2e9c2](https://github.com/richwklein/agingdeveloper/commit/ce2e9c26d26343bba4a8373cfcd6e466a4913abc))
+* Fix makefile and simplfy gatsby-config ([cbdb7ad](https://github.com/richwklein/agingdeveloper/commit/cbdb7ad7fcebed6b32d0b7e3ed3ac12454ffef19))
+* Set up canonical urls ([5a9e323](https://github.com/richwklein/agingdeveloper/commit/5a9e323db2fe50e6b839106203d8a42ebb778f38))
+* Set up makefile and move todos to github issues ([49595b9](https://github.com/richwklein/agingdeveloper/commit/49595b97edaadb30cbe9b7d75985f2b2fb194a33))
+* Move the table of contents ([c426c39](https://github.com/richwklein/agingdeveloper/commit/c426c395bf56949dcec70c468d454c7b333e4009))
+* Move the table of contents ([5283668](https://github.com/richwklein/agingdeveloper/commit/52836684ed8a87e682d923071059adaf055cb98d))
+* Move the table of contents ([9ddea92](https://github.com/richwklein/agingdeveloper/commit/9ddea9206ac8aaa95889ad2561fcf05af7a07ba8))
+* Move the table of contents ([730bfc6](https://github.com/richwklein/agingdeveloper/commit/730bfc6b9a244bcd5a3aee160518c2263b30d18d))
+* Move the table of contents ([b6e779b](https://github.com/richwklein/agingdeveloper/commit/b6e779b9e4847448c0cc801f52445ee73e7b76ee))
+* change path to mocks ([622203e](https://github.com/richwklein/agingdeveloper/commit/622203e86a3ef376c32792b77e5ad686f0d7b2a8))
+* fix path to license ([32d097a](https://github.com/richwklein/agingdeveloper/commit/32d097aad620109d20165d5b13cb373e1884c530))
+* Define Licensing ([f8ff285](https://github.com/richwklein/agingdeveloper/commit/f8ff285b6c8080742f3cfb55a5f892e6f4eb7ce1))
+* Add sitemap and robots files ([1425b1d](https://github.com/richwklein/agingdeveloper/commit/1425b1db300420171d20dd8389f76beeac295dc8))
+* Add sitemap and robots files ([cb85297](https://github.com/richwklein/agingdeveloper/commit/cb8529784e4ed578b2d5af34db4ce8b55f3bdc46))
+* Initial Titlebar implementation ([b0c825a](https://github.com/richwklein/agingdeveloper/commit/b0c825a94357788397d62318561bf094098826e5))
+* Update gitignore to include package-lock ([4a712bd](https://github.com/richwklein/agingdeveloper/commit/4a712bd0bc759385ae6b35b6e68e91ea769e0eb7))
+* Remove package-lock.json from repo ([47c6a40](https://github.com/richwklein/agingdeveloper/commit/47c6a405ae72148c27ce677e6b7bbcd8ca849217))
+* Set up code owners ([64d2b2e](https://github.com/richwklein/agingdeveloper/commit/64d2b2ef7157e930729852dcaa100960f3fec288))
+* Prettify code and fix lint issues ([cae99a4](https://github.com/richwklein/agingdeveloper/commit/cae99a458daefb2b5bbc0ebb9a829e39892eb056))
+* Prettify code and fix lint issues ([a3939b4](https://github.com/richwklein/agingdeveloper/commit/a3939b45d198e3bf72fcf1ad4aa9b109e23d7e5f))
+* Prettify code and fix lint issues ([4cf70f5](https://github.com/richwklein/agingdeveloper/commit/4cf70f5b9ebd832e024799a0d5cf45f5e8a907c8))
+* Prettify code and fix lint issues ([89f7b14](https://github.com/richwklein/agingdeveloper/commit/89f7b1414cfdc52f385ba8fe4914ddf1c831d007))
+* Make the move to an empty gatsby project ([f5543bb](https://github.com/richwklein/agingdeveloper/commit/f5543bb43afcce53a681aa07dd9bda6c1fd5360e))
+* Tweaking the readme ([b03a4aa](https://github.com/richwklein/agingdeveloper/commit/b03a4aa2df2205d2647da2ca58fe23d1d1a1c7ee))
+* Tweaking the readyme ([eba1445](https://github.com/richwklein/agingdeveloper/commit/eba14454e65ca2a5549306f80ec80139391565e7))
+* Tweaking the readme file ([25e0c0c](https://github.com/richwklein/agingdeveloper/commit/25e0c0c03fd0df1884d64ee93c5f6e612078cd39))
+* Update README.md ([a7f10aa](https://github.com/richwklein/agingdeveloper/commit/a7f10aa0faa412f1593081e0508e956461769e7f))
+* Update README.md ([b880597](https://github.com/richwklein/agingdeveloper/commit/b8805978fbae38e8ad2c561133ad35fb6f320c33))
+* Update README.md ([8483d6b](https://github.com/richwklein/agingdeveloper/commit/8483d6b815ea55102c8fdab7d60dfb9be98302c6))
+* Update the readme ([017ebb9](https://github.com/richwklein/agingdeveloper/commit/017ebb9ade668b4fd8eb045fc8bd4e68a7e9d4f5))
+* More cleanup ([a41580d](https://github.com/richwklein/agingdeveloper/commit/a41580d40c7c97dafd3e383f51b7a7e83b5af123))
+* Remove dead content ([90ce3bb](https://github.com/richwklein/agingdeveloper/commit/90ce3bb7f12da9428e561d8263da311b94a0cc49))
+* Updates to gitignore and jshint ([1f12a99](https://github.com/richwklein/agingdeveloper/commit/1f12a99af178cadb9c743d8e57617f732a4cf8df))
+* Site metadata ([6c4aec2](https://github.com/richwklein/agingdeveloper/commit/6c4aec25b95b4386d71e2b2e7717dbb714068c11))
+* Cleaning up gitignore ([569ea39](https://github.com/richwklein/agingdeveloper/commit/569ea398d86a9b2c95b0207d5e5e3dd4474907e7))
+* Initial commit from gatsby: (git@github.com:gatsbyjs/gatsby-starter-blog.git) ([aa43efc](https://github.com/richwklein/agingdeveloper/commit/aa43efc279b570c4469b9634468350df79efe72e))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,1099 +4,1099 @@
 
 ### Miscellaneous Changes
 
-* **quote:** add weekly quote for May 11, 2026 ([#899](https://github.com/richwklein/agingdeveloper/issues/899)) ([ca42cdc](https://github.com/richwklein/agingdeveloper/commit/ca42cdcc967976e2d28ed95ee3fd1ab0dc59cbcf))
+- **quote:** add weekly quote for May 11, 2026 ([#899](https://github.com/richwklein/agingdeveloper/issues/899)) ([ca42cdc](https://github.com/richwklein/agingdeveloper/commit/ca42cdcc967976e2d28ed95ee3fd1ab0dc59cbcf))
 
 ## [6.8.0](https://github.com/richwklein/agingdeveloper/compare/6.7.0...6.8.0) (2026-05-06)
 
 ### Miscellaneous Changes
 
-* bump dependencies and version to 6.8.0 ([#897](https://github.com/richwklein/agingdeveloper/issues/897)) ([588b059](https://github.com/richwklein/agingdeveloper/commit/588b05942f7f3b2d6daea20fbcb4af23ec09d9bb))
+- bump dependencies and version to 6.8.0 ([#897](https://github.com/richwklein/agingdeveloper/issues/897)) ([588b059](https://github.com/richwklein/agingdeveloper/commit/588b05942f7f3b2d6daea20fbcb4af23ec09d9bb))
 
 ## [6.7.0](https://github.com/richwklein/agingdeveloper/compare/6.6.7...6.7.0) (2026-05-05)
 
 ### Bug Fixes
 
-* **article-card:** equalize heights at medium breakpoint ([#890](https://github.com/richwklein/agingdeveloper/issues/890)) ([321460a](https://github.com/richwklein/agingdeveloper/commit/321460a4f051844c9d03eb3d5371e504eebfd413))
+- **article-card:** equalize heights at medium breakpoint ([#890](https://github.com/richwklein/agingdeveloper/issues/890)) ([321460a](https://github.com/richwklein/agingdeveloper/commit/321460a4f051844c9d03eb3d5371e504eebfd413))
 
 ## [6.6.7](https://github.com/richwklein/agingdeveloper/compare/6.6.6...6.6.7) (2026-05-05)
 
 ### Miscellaneous Changes
 
-* **quote:** add weekly quote for May 5, 2026 ([#894](https://github.com/richwklein/agingdeveloper/issues/894)) ([974ebc8](https://github.com/richwklein/agingdeveloper/commit/974ebc8205378353e27cff88eb94d9c7051c66a8))
+- **quote:** add weekly quote for May 5, 2026 ([#894](https://github.com/richwklein/agingdeveloper/issues/894)) ([974ebc8](https://github.com/richwklein/agingdeveloper/commit/974ebc8205378353e27cff88eb94d9c7051c66a8))
 
 ## [6.6.6](https://github.com/richwklein/agingdeveloper/compare/6.6.4...6.6.6) (2026-04-27)
 
 ### Miscellaneous Changes
 
-* **quote:** add weekly quote for April 27, 2026 ([#891](https://github.com/richwklein/agingdeveloper/issues/891)) ([037ea33](https://github.com/richwklein/agingdeveloper/commit/037ea3369c290ad8477d928908628f77dbd8a55c))
+- **quote:** add weekly quote for April 27, 2026 ([#891](https://github.com/richwklein/agingdeveloper/issues/891)) ([037ea33](https://github.com/richwklein/agingdeveloper/commit/037ea3369c290ad8477d928908628f77dbd8a55c))
 
 ## [6.6.4](https://github.com/richwklein/agingdeveloper/compare/6.6.3...6.6.4) (2026-04-20)
 
 ### Miscellaneous Changes
 
-* **quote:** add weekly quote for April 20, 2026 ([#887](https://github.com/richwklein/agingdeveloper/issues/887)) ([aff18a9](https://github.com/richwklein/agingdeveloper/commit/aff18a934567522906413caa3aad8f213958b541))
+- **quote:** add weekly quote for April 20, 2026 ([#887](https://github.com/richwklein/agingdeveloper/issues/887)) ([aff18a9](https://github.com/richwklein/agingdeveloper/commit/aff18a934567522906413caa3aad8f213958b541))
 
 ## [6.6.3](https://github.com/richwklein/agingdeveloper/compare/6.6.1...6.6.3) (2026-04-19)
 
 ### Miscellaneous Changes
 
-* **lighthouse:** inherit reusable workflow permissions and bump release ([#886](https://github.com/richwklein/agingdeveloper/issues/886)) ([151dc39](https://github.com/richwklein/agingdeveloper/commit/151dc39181822ba097b37087847b7fd2d227f6d5))
-* **lighthouse:** run mobile and desktop profiles with summary output ([#885](https://github.com/richwklein/agingdeveloper/issues/885)) ([d38b32e](https://github.com/richwklein/agingdeveloper/commit/d38b32ea945f1b39c823d9a2c1f17d606df7a8ef))
+- **lighthouse:** inherit reusable workflow permissions and bump release ([#886](https://github.com/richwklein/agingdeveloper/issues/886)) ([151dc39](https://github.com/richwklein/agingdeveloper/commit/151dc39181822ba097b37087847b7fd2d227f6d5))
+- **lighthouse:** run mobile and desktop profiles with summary output ([#885](https://github.com/richwklein/agingdeveloper/issues/885)) ([d38b32e](https://github.com/richwklein/agingdeveloper/commit/d38b32ea945f1b39c823d9a2c1f17d606df7a8ef))
 
 ## [6.6.1](https://github.com/richwklein/agingdeveloper/compare/6.6.0...6.6.1) (2026-04-19)
 
 ### Performance Improvements
 
-* **home:** preload QuoteCardLead chalkboard background image ([#882](https://github.com/richwklein/agingdeveloper/issues/882)) ([6e9e500](https://github.com/richwklein/agingdeveloper/commit/6e9e500de5c855f7a78140618b430cfa0dcefbd7))
+- **home:** preload QuoteCardLead chalkboard background image ([#882](https://github.com/richwklein/agingdeveloper/issues/882)) ([6e9e500](https://github.com/richwklein/agingdeveloper/commit/6e9e500de5c855f7a78140618b430cfa0dcefbd7))
 
 ## [6.6.0](https://github.com/richwklein/agingdeveloper/compare/6.5.0...6.6.0) (2026-04-18)
 
 ### Miscellaneous Changes
 
-* audit dependencies for static Astro build ([#880](https://github.com/richwklein/agingdeveloper/issues/880)) ([369146d](https://github.com/richwklein/agingdeveloper/commit/369146dc3a1b6ef25792e113d83ab4dc1d80ea03))
+- audit dependencies for static Astro build ([#880](https://github.com/richwklein/agingdeveloper/issues/880)) ([369146d](https://github.com/richwklein/agingdeveloper/commit/369146dc3a1b6ef25792e113d83ab4dc1d80ea03))
 
 ## [6.5.0](https://github.com/richwklein/agingdeveloper/compare/6.4.0...6.5.0) (2026-04-18)
 
 ### Features
 
-* **theme:** add dark mode support and persistent theme switcher ([#877](https://github.com/richwklein/agingdeveloper/issues/877)) ([1c9af27](https://github.com/richwklein/agingdeveloper/commit/1c9af2793513806d465bed3415ca12991b242a04))
+- **theme:** add dark mode support and persistent theme switcher ([#877](https://github.com/richwklein/agingdeveloper/issues/877)) ([1c9af27](https://github.com/richwklein/agingdeveloper/commit/1c9af2793513806d465bed3415ca12991b242a04))
 
 ### Miscellaneous Changes
 
-* Bump sanitize-html from 2.17.2 to 2.17.3 ([#876](https://github.com/richwklein/agingdeveloper/issues/876)) ([c9373d4](https://github.com/richwklein/agingdeveloper/commit/c9373d400f9ea1f76c9f8dd2257bbae1e9f57e99))
-* fix Netlify release deploy output handling ([#875](https://github.com/richwklein/agingdeveloper/issues/875)) ([4ddb17f](https://github.com/richwklein/agingdeveloper/commit/4ddb17f2260e94d3d4eb3cf0723934a259393df6))
+- Bump sanitize-html from 2.17.2 to 2.17.3 ([#876](https://github.com/richwklein/agingdeveloper/issues/876)) ([c9373d4](https://github.com/richwklein/agingdeveloper/commit/c9373d400f9ea1f76c9f8dd2257bbae1e9f57e99))
+- fix Netlify release deploy output handling ([#875](https://github.com/richwklein/agingdeveloper/issues/875)) ([4ddb17f](https://github.com/richwklein/agingdeveloper/commit/4ddb17f2260e94d3d4eb3cf0723934a259393df6))
 
 ## [6.4.0](https://github.com/richwklein/agingdeveloper/compare/6.3.1...6.4.0) (2026-04-16)
 
 ### Bug Fixes
 
-* **home:** rebalance lead and quote cards on responsive layouts ([#874](https://github.com/richwklein/agingdeveloper/issues/874)) ([fc67035](https://github.com/richwklein/agingdeveloper/commit/fc670354687a0a5a7020421be2ced039525cfa94))
+- **home:** rebalance lead and quote cards on responsive layouts ([#874](https://github.com/richwklein/agingdeveloper/issues/874)) ([fc67035](https://github.com/richwklein/agingdeveloper/commit/fc670354687a0a5a7020421be2ced039525cfa94))
 
 ### Miscellaneous Changes
 
-* Bump the other-dependencies group with 2 updates ([#867](https://github.com/richwklein/agingdeveloper/issues/867)) ([027fbe4](https://github.com/richwklein/agingdeveloper/commit/027fbe40ff01b98f1b2acff4853ba170e10f278a))
-* Bump the eslint group across 1 directory with 2 updates ([#871](https://github.com/richwklein/agingdeveloper/issues/871)) ([5050969](https://github.com/richwklein/agingdeveloper/commit/50509692323197ecda478aac3c26dc5e3f5681fa))
+- Bump the other-dependencies group with 2 updates ([#867](https://github.com/richwklein/agingdeveloper/issues/867)) ([027fbe4](https://github.com/richwklein/agingdeveloper/commit/027fbe40ff01b98f1b2acff4853ba170e10f278a))
+- Bump the eslint group across 1 directory with 2 updates ([#871](https://github.com/richwklein/agingdeveloper/issues/871)) ([5050969](https://github.com/richwklein/agingdeveloper/commit/50509692323197ecda478aac3c26dc5e3f5681fa))
 
 ## [6.3.1](https://github.com/richwklein/agingdeveloper/compare/6.2.1...6.3.1) (2026-04-16)
 
 ### Features
 
-* **images:** add responsive image placeholder pipeline ([#872](https://github.com/richwklein/agingdeveloper/issues/872)) ([ffc5ad1](https://github.com/richwklein/agingdeveloper/commit/ffc5ad188d0d01622177889f0b87b80fc6e7b691))
+- **images:** add responsive image placeholder pipeline ([#872](https://github.com/richwklein/agingdeveloper/issues/872)) ([ffc5ad1](https://github.com/richwklein/agingdeveloper/commit/ffc5ad188d0d01622177889f0b87b80fc6e7b691))
 
 ### Miscellaneous Changes
 
-* **github:** add issue forms and gate deploy previews ([#865](https://github.com/richwklein/agingdeveloper/issues/865)) ([f018835](https://github.com/richwklein/agingdeveloper/commit/f01883572c10883b88a8f684bf87c04ec8dd2dd6))
-* add Lighthouse CI checks for deployed sites ([#863](https://github.com/richwklein/agingdeveloper/issues/863)) ([81f14cd](https://github.com/richwklein/agingdeveloper/commit/81f14cd26d3ef5f3a4291333e6fb2f6a663869c1))
+- **github:** add issue forms and gate deploy previews ([#865](https://github.com/richwklein/agingdeveloper/issues/865)) ([f018835](https://github.com/richwklein/agingdeveloper/commit/f01883572c10883b88a8f684bf87c04ec8dd2dd6))
+- add Lighthouse CI checks for deployed sites ([#863](https://github.com/richwklein/agingdeveloper/issues/863)) ([81f14cd](https://github.com/richwklein/agingdeveloper/commit/81f14cd26d3ef5f3a4291333e6fb2f6a663869c1))
 
 ## [6.2.1](https://github.com/richwklein/agingdeveloper/compare/6.2.0...6.2.1) (2026-04-11)
 
 ### Miscellaneous Changes
 
-* [codex] move Astro fonts into the asset pipeline ([#862](https://github.com/richwklein/agingdeveloper/issues/862)) ([04fd324](https://github.com/richwklein/agingdeveloper/commit/04fd324a1725533ec61fcc60d7d9c36108b36e75))
+- [codex] move Astro fonts into the asset pipeline ([#862](https://github.com/richwklein/agingdeveloper/issues/862)) ([04fd324](https://github.com/richwklein/agingdeveloper/commit/04fd324a1725533ec61fcc60d7d9c36108b36e75))
 
 ## [6.2.0](https://github.com/richwklein/agingdeveloper/compare/6.1.0...6.2.0) (2026-04-10)
 
 ### Miscellaneous Changes
 
-* [codex] Add responsive header search ([#860](https://github.com/richwklein/agingdeveloper/issues/860)) ([c0ac4fe](https://github.com/richwklein/agingdeveloper/commit/c0ac4fe1abf2d69e470c4a773334ab2b1a750df7))
+- [codex] Add responsive header search ([#860](https://github.com/richwklein/agingdeveloper/issues/860)) ([c0ac4fe](https://github.com/richwklein/agingdeveloper/commit/c0ac4fe1abf2d69e470c4a773334ab2b1a750df7))
 
 ## [6.1.0](https://github.com/richwklein/agingdeveloper/compare/6.0.0...6.1.0) (2026-04-10)
 
 ### Miscellaneous Changes
 
-* [codex] Add featured images to syndicated feed items ([#858](https://github.com/richwklein/agingdeveloper/issues/858)) ([6cb4c36](https://github.com/richwklein/agingdeveloper/commit/6cb4c36cce05c0ad2ae520375ad41c234c472134))
-* Bump the eslint group across 1 directory with 4 updates ([#857](https://github.com/richwklein/agingdeveloper/issues/857)) ([ed5f710](https://github.com/richwklein/agingdeveloper/commit/ed5f710622959eb57fda0fd7b37ca38654526337))
+- [codex] Add featured images to syndicated feed items ([#858](https://github.com/richwklein/agingdeveloper/issues/858)) ([6cb4c36](https://github.com/richwklein/agingdeveloper/commit/6cb4c36cce05c0ad2ae520375ad41c234c472134))
+- Bump the eslint group across 1 directory with 4 updates ([#857](https://github.com/richwklein/agingdeveloper/issues/857)) ([ed5f710](https://github.com/richwklein/agingdeveloper/commit/ed5f710622959eb57fda0fd7b37ca38654526337))
 
 ## [6.0.0](https://github.com/richwklein/agingdeveloper/compare/5.10.1...6.0.0) (2026-04-10)
 
 ### Miscellaneous Changes
 
-* [codex] upgrade Astro tooling and remove standalone markdown lint workflow ([#856](https://github.com/richwklein/agingdeveloper/issues/856)) ([ee4d7bb](https://github.com/richwklein/agingdeveloper/commit/ee4d7bb9abe7a4f458224e5a80052637ab7550e1))
+- [codex] upgrade Astro tooling and remove standalone markdown lint workflow ([#856](https://github.com/richwklein/agingdeveloper/issues/856)) ([ee4d7bb](https://github.com/richwklein/agingdeveloper/commit/ee4d7bb9abe7a4f458224e5a80052637ab7550e1))
 
 ## [5.10.1](https://github.com/richwklein/agingdeveloper/compare/5.10.0...5.10.1) (2026-04-06)
 
 ### Miscellaneous Changes
 
-* cut v5.10.1 ([#854](https://github.com/richwklein/agingdeveloper/issues/854)) ([fa4218c](https://github.com/richwklein/agingdeveloper/commit/fa4218c28cb54bad301b239b9606e83ac8761ca2))
+- cut v5.10.1 ([#854](https://github.com/richwklein/agingdeveloper/issues/854)) ([fa4218c](https://github.com/richwklein/agingdeveloper/commit/fa4218c28cb54bad301b239b9606e83ac8761ca2))
 
 ## [5.10.0](https://github.com/richwklein/agingdeveloper/compare/5.9.0...5.10.0) (2026-04-05)
 
 ### Miscellaneous Changes
 
-* Integrate fuse directly ([#853](https://github.com/richwklein/agingdeveloper/issues/853)) ([29bcf45](https://github.com/richwklein/agingdeveloper/commit/29bcf45fd7df5d6bfabcf12122c470883947d1b5))
+- Integrate fuse directly ([#853](https://github.com/richwklein/agingdeveloper/issues/853)) ([29bcf45](https://github.com/richwklein/agingdeveloper/commit/29bcf45fd7df5d6bfabcf12122c470883947d1b5))
 
 ## [5.9.0](https://github.com/richwklein/agingdeveloper/compare/5.8.3...5.9.0) (2026-04-04)
 
 ### Miscellaneous Changes
 
-* Article about creating an IRS account and how that reflects on the SAVE Act ([#852](https://github.com/richwklein/agingdeveloper/issues/852)) ([57f3bcf](https://github.com/richwklein/agingdeveloper/commit/57f3bcfc97b649a451b7aeca6f45fad0188dcb13))
-* Bump the eslint group with 2 updates ([#825](https://github.com/richwklein/agingdeveloper/issues/825)) ([768a3f1](https://github.com/richwklein/agingdeveloper/commit/768a3f1b00bdd5b57a64349dc53c3f2b8aa009ed))
-* Bump the github-actions group across 1 directory with 3 updates ([#831](https://github.com/richwklein/agingdeveloper/issues/831)) ([e866c33](https://github.com/richwklein/agingdeveloper/commit/e866c337332c778c94bfb68b6912acb3a21f5dd7))
+- Article about creating an IRS account and how that reflects on the SAVE Act ([#852](https://github.com/richwklein/agingdeveloper/issues/852)) ([57f3bcf](https://github.com/richwklein/agingdeveloper/commit/57f3bcfc97b649a451b7aeca6f45fad0188dcb13))
+- Bump the eslint group with 2 updates ([#825](https://github.com/richwklein/agingdeveloper/issues/825)) ([768a3f1](https://github.com/richwklein/agingdeveloper/commit/768a3f1b00bdd5b57a64349dc53c3f2b8aa009ed))
+- Bump the github-actions group across 1 directory with 3 updates ([#831](https://github.com/richwklein/agingdeveloper/issues/831)) ([e866c33](https://github.com/richwklein/agingdeveloper/commit/e866c337332c778c94bfb68b6912acb3a21f5dd7))
 
 ## [5.8.3](https://github.com/richwklein/agingdeveloper/compare/5.8.2...5.8.3) (2026-03-23)
 
 ### Miscellaneous Changes
 
-* Quote for the week of March 23rd, 2026 ([#851](https://github.com/richwklein/agingdeveloper/issues/851)) ([c414ef7](https://github.com/richwklein/agingdeveloper/commit/c414ef7626e81c5ee3a345072b89b973bcebc6ba))
+- Quote for the week of March 23rd, 2026 ([#851](https://github.com/richwklein/agingdeveloper/issues/851)) ([c414ef7](https://github.com/richwklein/agingdeveloper/commit/c414ef7626e81c5ee3a345072b89b973bcebc6ba))
 
 ## [5.8.2](https://github.com/richwklein/agingdeveloper/compare/5.8.1...5.8.2) (2026-03-23)
 
 ### Miscellaneous Changes
 
-* fixes needed from the switch to github actions for build and deploy ([#850](https://github.com/richwklein/agingdeveloper/issues/850)) ([3182783](https://github.com/richwklein/agingdeveloper/commit/31827834ceaf76b5d04291518df14977a324084b))
+- fixes needed from the switch to github actions for build and deploy ([#850](https://github.com/richwklein/agingdeveloper/issues/850)) ([3182783](https://github.com/richwklein/agingdeveloper/commit/31827834ceaf76b5d04291518df14977a324084b))
 
 ## [5.8.1](https://github.com/richwklein/agingdeveloper/compare/5.8.0...5.8.1) (2026-03-21)
 
 ### Miscellaneous Changes
 
-* Tag release ([#849](https://github.com/richwklein/agingdeveloper/issues/849)) ([0f6273f](https://github.com/richwklein/agingdeveloper/commit/0f6273f560edd429b8c8567b619e5b6aacd595e5))
+- Tag release ([#849](https://github.com/richwklein/agingdeveloper/issues/849)) ([0f6273f](https://github.com/richwklein/agingdeveloper/commit/0f6273f560edd429b8c8567b619e5b6aacd595e5))
 
 ## [5.8.0](https://github.com/richwklein/agingdeveloper/compare/5.7.5...5.8.0) (2026-03-21)
 
 ### Miscellaneous Changes
 
-* Switch to pnpm as the package manager. ([#848](https://github.com/richwklein/agingdeveloper/issues/848)) ([a3f85c5](https://github.com/richwklein/agingdeveloper/commit/a3f85c50239f89a685a5fee8159cdde73e4e7988))
-* Netlify tagged ([#846](https://github.com/richwklein/agingdeveloper/issues/846)) ([db7c6d8](https://github.com/richwklein/agingdeveloper/commit/db7c6d8f0423e29b44b2e4116a02ac802759c343))
-* Switch to using github actions for build and deploy ([#834](https://github.com/richwklein/agingdeveloper/issues/834)) ([edd867a](https://github.com/richwklein/agingdeveloper/commit/edd867a2dcf7ebe590fafd118bb89b24d9392eba))
+- Switch to pnpm as the package manager. ([#848](https://github.com/richwklein/agingdeveloper/issues/848)) ([a3f85c5](https://github.com/richwklein/agingdeveloper/commit/a3f85c50239f89a685a5fee8159cdde73e4e7988))
+- Netlify tagged ([#846](https://github.com/richwklein/agingdeveloper/issues/846)) ([db7c6d8](https://github.com/richwklein/agingdeveloper/commit/db7c6d8f0423e29b44b2e4116a02ac802759c343))
+- Switch to using github actions for build and deploy ([#834](https://github.com/richwklein/agingdeveloper/issues/834)) ([edd867a](https://github.com/richwklein/agingdeveloper/commit/edd867a2dcf7ebe590fafd118bb89b24d9392eba))
 
 ## [5.7.5](https://github.com/richwklein/agingdeveloper/compare/5.7.4...5.7.5) (2026-03-16)
 
 ### Miscellaneous Changes
 
-* Quote for the week of March 16th, 2026 ([#829](https://github.com/richwklein/agingdeveloper/issues/829)) ([3e7c2a0](https://github.com/richwklein/agingdeveloper/commit/3e7c2a065445288ef216f06b69eae5f2162825dc))
+- Quote for the week of March 16th, 2026 ([#829](https://github.com/richwklein/agingdeveloper/issues/829)) ([3e7c2a0](https://github.com/richwklein/agingdeveloper/commit/3e7c2a065445288ef216f06b69eae5f2162825dc))
 
 ## [5.7.4](https://github.com/richwklein/agingdeveloper/compare/5.7.3...5.7.4) (2026-03-09)
 
 ### Miscellaneous Changes
 
-* Quote for the week of March 9th, 2026 ([#828](https://github.com/richwklein/agingdeveloper/issues/828)) ([9d4f75b](https://github.com/richwklein/agingdeveloper/commit/9d4f75b2bc75078d1f77d384064a7f5b2ddd8a35))
+- Quote for the week of March 9th, 2026 ([#828](https://github.com/richwklein/agingdeveloper/issues/828)) ([9d4f75b](https://github.com/richwklein/agingdeveloper/commit/9d4f75b2bc75078d1f77d384064a7f5b2ddd8a35))
 
 ## [5.7.3](https://github.com/richwklein/agingdeveloper/compare/5.7.2...5.7.3) (2026-03-02)
 
 ### Miscellaneous Changes
 
-* Quote for the week of March 2nd, 2026 ([#827](https://github.com/richwklein/agingdeveloper/issues/827)) ([fbe799c](https://github.com/richwklein/agingdeveloper/commit/fbe799c619961e089e2e67b70eb13431ddc103e8))
+- Quote for the week of March 2nd, 2026 ([#827](https://github.com/richwklein/agingdeveloper/issues/827)) ([fbe799c](https://github.com/richwklein/agingdeveloper/commit/fbe799c619961e089e2e67b70eb13431ddc103e8))
 
 ## [5.7.2](https://github.com/richwklein/agingdeveloper/compare/5.7.1...5.7.2) (2026-02-23)
 
 ### Miscellaneous Changes
 
-* Quote for the week of 2026-02-23 ([#826](https://github.com/richwklein/agingdeveloper/issues/826)) ([50881df](https://github.com/richwklein/agingdeveloper/commit/50881df16e478b466e4b5ef180e6403f7d214a64))
+- Quote for the week of 2026-02-23 ([#826](https://github.com/richwklein/agingdeveloper/issues/826)) ([50881df](https://github.com/richwklein/agingdeveloper/commit/50881df16e478b466e4b5ef180e6403f7d214a64))
 
 ## [5.7.1](https://github.com/richwklein/agingdeveloper/compare/5.7.0...5.7.1) (2026-02-16)
 
 ### Miscellaneous Changes
 
-* This weeks quote and updated "popular" articles ([#824](https://github.com/richwklein/agingdeveloper/issues/824)) ([d37f400](https://github.com/richwklein/agingdeveloper/commit/d37f40068e22b6e7f54005d5d800676d414dcd2f))
+- This weeks quote and updated "popular" articles ([#824](https://github.com/richwklein/agingdeveloper/issues/824)) ([d37f400](https://github.com/richwklein/agingdeveloper/commit/d37f40068e22b6e7f54005d5d800676d414dcd2f))
 
 ## [5.7.0](https://github.com/richwklein/agingdeveloper/compare/5.6.5...5.7.0) (2026-02-12)
 
 ### Miscellaneous Changes
 
-* Quote of the week 2026-02-12 and a new source type "magazine" ([#823](https://github.com/richwklein/agingdeveloper/issues/823)) ([b1ae542](https://github.com/richwklein/agingdeveloper/commit/b1ae5421fb19bd1dbc8228811d08358d2475c6e5))
+- Quote of the week 2026-02-12 and a new source type "magazine" ([#823](https://github.com/richwklein/agingdeveloper/issues/823)) ([b1ae542](https://github.com/richwklein/agingdeveloper/commit/b1ae5421fb19bd1dbc8228811d08358d2475c6e5))
 
 ## [5.6.5](https://github.com/richwklein/agingdeveloper/compare/5.6.4...5.6.5) (2026-02-02)
 
 ### Miscellaneous Changes
 
-* Quote for the week of February 2nd, 2026 ([#822](https://github.com/richwklein/agingdeveloper/issues/822)) ([34b31cd](https://github.com/richwklein/agingdeveloper/commit/34b31cd8d65dd655e64d57e4bbd6f8d8591b80c7))
+- Quote for the week of February 2nd, 2026 ([#822](https://github.com/richwklein/agingdeveloper/issues/822)) ([34b31cd](https://github.com/richwklein/agingdeveloper/commit/34b31cd8d65dd655e64d57e4bbd6f8d8591b80c7))
 
 ## [5.6.4](https://github.com/richwklein/agingdeveloper/compare/5.6.3...5.6.4) (2026-01-30)
 
 ### Miscellaneous Changes
 
-* Article about "Healthier new year" ([#821](https://github.com/richwklein/agingdeveloper/issues/821)) ([5b3fcbc](https://github.com/richwklein/agingdeveloper/commit/5b3fcbc0681173631f46da3307112e8ca9d91ccb))
+- Article about "Healthier new year" ([#821](https://github.com/richwklein/agingdeveloper/issues/821)) ([5b3fcbc](https://github.com/richwklein/agingdeveloper/commit/5b3fcbc0681173631f46da3307112e8ca9d91ccb))
 
 ## [5.6.3](https://github.com/richwklein/agingdeveloper/compare/5.6.2...5.6.3) (2026-01-26)
 
 ### Miscellaneous Changes
 
-* Quote for the week of January 26th, 2026 ([#820](https://github.com/richwklein/agingdeveloper/issues/820)) ([1deff3d](https://github.com/richwklein/agingdeveloper/commit/1deff3d794e69507927885ac3440e5c466ac95f2))
+- Quote for the week of January 26th, 2026 ([#820](https://github.com/richwklein/agingdeveloper/issues/820)) ([1deff3d](https://github.com/richwklein/agingdeveloper/commit/1deff3d794e69507927885ac3440e5c466ac95f2))
 
 ## [5.6.2](https://github.com/richwklein/agingdeveloper/compare/5.6.1...5.6.2) (2026-01-19)
 
 ### Miscellaneous Changes
 
-* Quote of the week for January 19th 2026 ([#819](https://github.com/richwklein/agingdeveloper/issues/819)) ([e82938c](https://github.com/richwklein/agingdeveloper/commit/e82938c7e3ee5ace9a429574bf79efffd5d6cc63))
+- Quote of the week for January 19th 2026 ([#819](https://github.com/richwklein/agingdeveloper/issues/819)) ([e82938c](https://github.com/richwklein/agingdeveloper/commit/e82938c7e3ee5ace9a429574bf79efffd5d6cc63))
 
 ## [5.6.1](https://github.com/richwklein/agingdeveloper/compare/5.6.0...5.6.1) (2026-01-13)
 
 ### Miscellaneous Changes
 
-* Quote for the week of January 12, 2026 ([#818](https://github.com/richwklein/agingdeveloper/issues/818)) ([7424465](https://github.com/richwklein/agingdeveloper/commit/74244658e1d8ed93cedb155fd855a68dfc042da8))
+- Quote for the week of January 12, 2026 ([#818](https://github.com/richwklein/agingdeveloper/issues/818)) ([7424465](https://github.com/richwklein/agingdeveloper/commit/74244658e1d8ed93cedb155fd855a68dfc042da8))
 
 ## [5.6.0](https://github.com/richwklein/agingdeveloper/compare/5.5.9...5.6.0) (2026-01-11)
 
 ### Miscellaneous Changes
 
-* New article on using AI to spot bias ([#817](https://github.com/richwklein/agingdeveloper/issues/817)) ([9a15696](https://github.com/richwklein/agingdeveloper/commit/9a15696cb24b770109b4151ee7dd0cdcf87d701f))
+- New article on using AI to spot bias ([#817](https://github.com/richwklein/agingdeveloper/issues/817)) ([9a15696](https://github.com/richwklein/agingdeveloper/commit/9a15696cb24b770109b4151ee7dd0cdcf87d701f))
 
 ## [5.5.9](https://github.com/richwklein/agingdeveloper/compare/5.5.8...5.5.9) (2026-01-05)
 
 ### Miscellaneous Changes
 
-* Quote of the week for January 5th, 2026 ([#816](https://github.com/richwklein/agingdeveloper/issues/816)) ([feed96a](https://github.com/richwklein/agingdeveloper/commit/feed96ae8a1675a204d5f0738d7841dbfecfceef))
+- Quote of the week for January 5th, 2026 ([#816](https://github.com/richwklein/agingdeveloper/issues/816)) ([feed96a](https://github.com/richwklein/agingdeveloper/commit/feed96ae8a1675a204d5f0738d7841dbfecfceef))
 
 ## [5.5.8](https://github.com/richwklein/agingdeveloper/compare/5.5.7...5.5.8) (2025-12-29)
 
 ### Miscellaneous Changes
 
-* Quote for the week of December 29th, 2025 ([#815](https://github.com/richwklein/agingdeveloper/issues/815)) ([7b07ac4](https://github.com/richwklein/agingdeveloper/commit/7b07ac4156759d1c968a115ed1034fd5474fb366))
-* New article about using emojis in pull request comments ([#814](https://github.com/richwklein/agingdeveloper/issues/814)) ([94f1e54](https://github.com/richwklein/agingdeveloper/commit/94f1e54a6a4b4e7dceff2ad0a97b773054850441))
+- Quote for the week of December 29th, 2025 ([#815](https://github.com/richwklein/agingdeveloper/issues/815)) ([7b07ac4](https://github.com/richwklein/agingdeveloper/commit/7b07ac4156759d1c968a115ed1034fd5474fb366))
+- New article about using emojis in pull request comments ([#814](https://github.com/richwklein/agingdeveloper/issues/814)) ([94f1e54](https://github.com/richwklein/agingdeveloper/commit/94f1e54a6a4b4e7dceff2ad0a97b773054850441))
 
 ## [5.5.7](https://github.com/richwklein/agingdeveloper/compare/5.5.6...5.5.7) (2025-12-23)
 
 ### Miscellaneous Changes
 
-* Quote for the week of December 22nd, 2025 ([#812](https://github.com/richwklein/agingdeveloper/issues/812)) ([c80f347](https://github.com/richwklein/agingdeveloper/commit/c80f347fbca9c5e8534c039e07e59400a3961c3c))
+- Quote for the week of December 22nd, 2025 ([#812](https://github.com/richwklein/agingdeveloper/issues/812)) ([c80f347](https://github.com/richwklein/agingdeveloper/commit/c80f347fbca9c5e8534c039e07e59400a3961c3c))
 
 ## [5.5.6](https://github.com/richwklein/agingdeveloper/compare/5.5.5...5.5.6) (2025-12-15)
 
 ### Miscellaneous Changes
 
-* Quote for the week of December 15th ([#811](https://github.com/richwklein/agingdeveloper/issues/811)) ([a28f62d](https://github.com/richwklein/agingdeveloper/commit/a28f62d5837a172f67292d7edb80d258a9a0f933))
-* Tweaks to the github actions ([#806](https://github.com/richwklein/agingdeveloper/issues/806)) ([aae03cb](https://github.com/richwklein/agingdeveloper/commit/aae03cb5541b507007dc403d4f83ab8101d7d4db))
-* Fix semver not supported for github actions ([#810](https://github.com/richwklein/agingdeveloper/issues/810)) ([d2864ff](https://github.com/richwklein/agingdeveloper/commit/d2864ff586cb0f778fc6f4639dfcef8371b489ec))
+- Quote for the week of December 15th ([#811](https://github.com/richwklein/agingdeveloper/issues/811)) ([a28f62d](https://github.com/richwklein/agingdeveloper/commit/a28f62d5837a172f67292d7edb80d258a9a0f933))
+- Tweaks to the github actions ([#806](https://github.com/richwklein/agingdeveloper/issues/806)) ([aae03cb](https://github.com/richwklein/agingdeveloper/commit/aae03cb5541b507007dc403d4f83ab8101d7d4db))
+- Fix semver not supported for github actions ([#810](https://github.com/richwklein/agingdeveloper/issues/810)) ([d2864ff](https://github.com/richwklein/agingdeveloper/commit/d2864ff586cb0f778fc6f4639dfcef8371b489ec))
 
 ## [5.5.5](https://github.com/richwklein/agingdeveloper/compare/5.5.4...5.5.5) (2025-12-13)
 
 ### Miscellaneous Changes
 
-* Dependency cooldown ([#809](https://github.com/richwklein/agingdeveloper/issues/809)) ([1bb319e](https://github.com/richwklein/agingdeveloper/commit/1bb319e7fe4ac753bd3ba2c6c3b36219d07d4455))
+- Dependency cooldown ([#809](https://github.com/richwklein/agingdeveloper/issues/809)) ([1bb319e](https://github.com/richwklein/agingdeveloper/commit/1bb319e7fe4ac753bd3ba2c6c3b36219d07d4455))
 
 ## [5.5.4](https://github.com/richwklein/agingdeveloper/compare/5.5.3...5.5.4) (2025-12-08)
 
 ### Miscellaneous Changes
 
-* Quote of the week for December 8th, 2025 ([#808](https://github.com/richwklein/agingdeveloper/issues/808)) ([79755c6](https://github.com/richwklein/agingdeveloper/commit/79755c6b0c05214a63b9fc85ce3cef6342bd30bc))
+- Quote of the week for December 8th, 2025 ([#808](https://github.com/richwklein/agingdeveloper/issues/808)) ([79755c6](https://github.com/richwklein/agingdeveloper/commit/79755c6b0c05214a63b9fc85ce3cef6342bd30bc))
 
 ## [5.5.3](https://github.com/richwklein/agingdeveloper/compare/5.5.2...5.5.3) (2025-12-01)
 
 ### Miscellaneous Changes
 
-* Quote of the week for 2025-12-01 ([#807](https://github.com/richwklein/agingdeveloper/issues/807)) ([2b2a814](https://github.com/richwklein/agingdeveloper/commit/2b2a814686b54767a0a25bf68ec2aaea3f5ab9e1))
-* Attempting to fix test reporting ([#805](https://github.com/richwklein/agingdeveloper/issues/805)) ([aa32444](https://github.com/richwklein/agingdeveloper/commit/aa32444329ca747dc61600c3e3cd00f77bd6071b))
-* Test coverage reporting ([#785](https://github.com/richwklein/agingdeveloper/issues/785)) ([cb87801](https://github.com/richwklein/agingdeveloper/commit/cb8780199232c43f338295706cb71259f6f76ce7))
+- Quote of the week for 2025-12-01 ([#807](https://github.com/richwklein/agingdeveloper/issues/807)) ([2b2a814](https://github.com/richwklein/agingdeveloper/commit/2b2a814686b54767a0a25bf68ec2aaea3f5ab9e1))
+- Attempting to fix test reporting ([#805](https://github.com/richwklein/agingdeveloper/issues/805)) ([aa32444](https://github.com/richwklein/agingdeveloper/commit/aa32444329ca747dc61600c3e3cd00f77bd6071b))
+- Test coverage reporting ([#785](https://github.com/richwklein/agingdeveloper/issues/785)) ([cb87801](https://github.com/richwklein/agingdeveloper/commit/cb8780199232c43f338295706cb71259f6f76ce7))
 
 ## [5.5.2](https://github.com/richwklein/agingdeveloper/compare/5.5.1...5.5.2) (2025-11-24)
 
 ### Miscellaneous Changes
 
-* Gracefully handle when the license icon does not exist ([#804](https://github.com/richwklein/agingdeveloper/issues/804)) ([eec9fbe](https://github.com/richwklein/agingdeveloper/commit/eec9fbe66f78ead8c0891ab4e06be96886927009))
+- Gracefully handle when the license icon does not exist ([#804](https://github.com/richwklein/agingdeveloper/issues/804)) ([eec9fbe](https://github.com/richwklein/agingdeveloper/commit/eec9fbe66f78ead8c0891ab4e06be96886927009))
 
 ## [5.5.1](https://github.com/richwklein/agingdeveloper/compare/5.5.0...5.5.1) (2025-11-24)
 
 ### Miscellaneous Changes
 
-* Licensing and Attribution Component ([#803](https://github.com/richwklein/agingdeveloper/issues/803)) ([1177e46](https://github.com/richwklein/agingdeveloper/commit/1177e46fc5e711664efd0c79538b1fda60241a40))
+- Licensing and Attribution Component ([#803](https://github.com/richwklein/agingdeveloper/issues/803)) ([1177e46](https://github.com/richwklein/agingdeveloper/commit/1177e46fc5e711664efd0c79538b1fda60241a40))
 
 ## [5.5.0](https://github.com/richwklein/agingdeveloper/compare/5.4.11...5.5.0) (2025-11-24)
 
 ### Miscellaneous Changes
 
-* Upgrade dependencies and publish quote for 2025-11-24 ([#802](https://github.com/richwklein/agingdeveloper/issues/802)) ([55cd9b6](https://github.com/richwklein/agingdeveloper/commit/55cd9b6fbd2e2abb5ed391359baff47e4149c9d8))
+- Upgrade dependencies and publish quote for 2025-11-24 ([#802](https://github.com/richwklein/agingdeveloper/issues/802)) ([55cd9b6](https://github.com/richwklein/agingdeveloper/commit/55cd9b6fbd2e2abb5ed391359baff47e4149c9d8))
 
 ## [5.4.11](https://github.com/richwklein/agingdeveloper/compare/5.4.10...5.4.11) (2025-11-17)
 
 ### Miscellaneous Changes
 
-* Quote for the week of November 17th, 2025 ([#800](https://github.com/richwklein/agingdeveloper/issues/800)) ([d523e59](https://github.com/richwklein/agingdeveloper/commit/d523e597ad179a378e2da4c4924106f9278518f4))
+- Quote for the week of November 17th, 2025 ([#800](https://github.com/richwklein/agingdeveloper/issues/800)) ([d523e59](https://github.com/richwklein/agingdeveloper/commit/d523e597ad179a378e2da4c4924106f9278518f4))
 
 ## [5.4.10](https://github.com/richwklein/agingdeveloper/compare/5.4.9...5.4.10) (2025-11-10)
 
 ### Miscellaneous Changes
 
-* Quote of the week - November 10th, 2025 ([#798](https://github.com/richwklein/agingdeveloper/issues/798)) ([fcb3c60](https://github.com/richwklein/agingdeveloper/commit/fcb3c6048800b05e9f64ae581ccc58e367017816))
-* Quote of the week for 2025-11-04 ([#797](https://github.com/richwklein/agingdeveloper/issues/797)) ([4fa526c](https://github.com/richwklein/agingdeveloper/commit/4fa526ca52a53e0fd29b08e47c2ab6b6876cb2f4))
+- Quote of the week - November 10th, 2025 ([#798](https://github.com/richwklein/agingdeveloper/issues/798)) ([fcb3c60](https://github.com/richwklein/agingdeveloper/commit/fcb3c6048800b05e9f64ae581ccc58e367017816))
+- Quote of the week for 2025-11-04 ([#797](https://github.com/richwklein/agingdeveloper/issues/797)) ([4fa526c](https://github.com/richwklein/agingdeveloper/commit/4fa526ca52a53e0fd29b08e47c2ab6b6876cb2f4))
 
 ## [5.4.9](https://github.com/richwklein/agingdeveloper/compare/5.4.8...5.4.9) (2025-10-27)
 
 ### Miscellaneous Changes
 
-* Quote of the Week 2025-10-27 ([#794](https://github.com/richwklein/agingdeveloper/issues/794)) ([436f3c9](https://github.com/richwklein/agingdeveloper/commit/436f3c9466afb91c053e69653ebeaf1e040dd17a))
+- Quote of the Week 2025-10-27 ([#794](https://github.com/richwklein/agingdeveloper/issues/794)) ([436f3c9](https://github.com/richwklein/agingdeveloper/commit/436f3c9466afb91c053e69653ebeaf1e040dd17a))
 
 ## [5.4.8](https://github.com/richwklein/agingdeveloper/compare/5.4.7...5.4.8) (2025-10-13)
 
 ### Miscellaneous Changes
 
-* Quote for the week of 2025-10-13 ([#791](https://github.com/richwklein/agingdeveloper/issues/791)) ([7941669](https://github.com/richwklein/agingdeveloper/commit/79416691d967e83c9860ab46896a02b199a376c7))
+- Quote for the week of 2025-10-13 ([#791](https://github.com/richwklein/agingdeveloper/issues/791)) ([7941669](https://github.com/richwklein/agingdeveloper/commit/79416691d967e83c9860ab46896a02b199a376c7))
 
 ## [5.4.7](https://github.com/richwklein/agingdeveloper/compare/5.4.6...5.4.7) (2025-10-07)
 
 ### Miscellaneous Changes
 
-* Change dependabot interval and ignore patch versions ([#789](https://github.com/richwklein/agingdeveloper/issues/789)) ([f589c8a](https://github.com/richwklein/agingdeveloper/commit/f589c8a484e40554226398717d7030eaf497e2de))
+- Change dependabot interval and ignore patch versions ([#789](https://github.com/richwklein/agingdeveloper/issues/789)) ([f589c8a](https://github.com/richwklein/agingdeveloper/commit/f589c8a484e40554226398717d7030eaf497e2de))
 
 ## [5.4.6](https://github.com/richwklein/agingdeveloper/compare/5.4.5...5.4.6) (2025-10-06)
 
 ### Miscellaneous Changes
 
-* Quote of the week for October 6th, 2025 ([#788](https://github.com/richwklein/agingdeveloper/issues/788)) ([b28e603](https://github.com/richwklein/agingdeveloper/commit/b28e603021855c50bb88fdc6d4e8bfdfd79968c9))
+- Quote of the week for October 6th, 2025 ([#788](https://github.com/richwklein/agingdeveloper/issues/788)) ([b28e603](https://github.com/richwklein/agingdeveloper/commit/b28e603021855c50bb88fdc6d4e8bfdfd79968c9))
 
 ## [5.4.5](https://github.com/richwklein/agingdeveloper/compare/5.4.4...5.4.5) (2025-09-29)
 
 ### Miscellaneous Changes
 
-* Quote for the week of 2025-09-29 ([#787](https://github.com/richwklein/agingdeveloper/issues/787)) ([a7d1225](https://github.com/richwklein/agingdeveloper/commit/a7d1225adc292e3e83656040f51f468c838e3582))
+- Quote for the week of 2025-09-29 ([#787](https://github.com/richwklein/agingdeveloper/issues/787)) ([a7d1225](https://github.com/richwklein/agingdeveloper/commit/a7d1225adc292e3e83656040f51f468c838e3582))
 
 ## [5.4.4](https://github.com/richwklein/agingdeveloper/compare/5.4.3...5.4.4) (2025-09-22)
 
 ### Miscellaneous Changes
 
-* Quote of the Week for 2025-09-21 ([#786](https://github.com/richwklein/agingdeveloper/issues/786)) ([a282cb7](https://github.com/richwklein/agingdeveloper/commit/a282cb7fe40d0fc7f6955b443ac8986344fada45))
+- Quote of the Week for 2025-09-21 ([#786](https://github.com/richwklein/agingdeveloper/issues/786)) ([a282cb7](https://github.com/richwklein/agingdeveloper/commit/a282cb7fe40d0fc7f6955b443ac8986344fada45))
 
 ## [5.4.3](https://github.com/richwklein/agingdeveloper/compare/5.4.2...5.4.3) (2025-09-15)
 
 ### Miscellaneous Changes
 
-* Quote of the week for 2025-09-15 ([#784](https://github.com/richwklein/agingdeveloper/issues/784)) ([5b3a8d8](https://github.com/richwklein/agingdeveloper/commit/5b3a8d8e36081f17c573f32b770567c867e923e4))
+- Quote of the week for 2025-09-15 ([#784](https://github.com/richwklein/agingdeveloper/issues/784)) ([5b3a8d8](https://github.com/richwklein/agingdeveloper/commit/5b3a8d8e36081f17c573f32b770567c867e923e4))
 
 ## [5.4.2](https://github.com/richwklein/agingdeveloper/compare/5.4.1...5.4.2) (2025-09-08)
 
 ### Miscellaneous Changes
 
-* Quote of the week for 20225-09-08 ([#782](https://github.com/richwklein/agingdeveloper/issues/782)) ([e4f97d8](https://github.com/richwklein/agingdeveloper/commit/e4f97d806220831509710fc3003c3d88ab642e0f))
-* Quote of the week for 2025-09-01 ([#780](https://github.com/richwklein/agingdeveloper/issues/780)) ([8636d59](https://github.com/richwklein/agingdeveloper/commit/8636d59f77f02ab370ac0f44ae7db2c0ea3adee1))
-* Bump the github-actions group across 1 directory with 2 updates ([#776](https://github.com/richwklein/agingdeveloper/issues/776)) ([6e1deee](https://github.com/richwklein/agingdeveloper/commit/6e1deee8bb6db39e3a22a1bc3b0562c147df7a1a))
+- Quote of the week for 20225-09-08 ([#782](https://github.com/richwklein/agingdeveloper/issues/782)) ([e4f97d8](https://github.com/richwklein/agingdeveloper/commit/e4f97d806220831509710fc3003c3d88ab642e0f))
+- Quote of the week for 2025-09-01 ([#780](https://github.com/richwklein/agingdeveloper/issues/780)) ([8636d59](https://github.com/richwklein/agingdeveloper/commit/8636d59f77f02ab370ac0f44ae7db2c0ea3adee1))
+- Bump the github-actions group across 1 directory with 2 updates ([#776](https://github.com/richwklein/agingdeveloper/issues/776)) ([6e1deee](https://github.com/richwklein/agingdeveloper/commit/6e1deee8bb6db39e3a22a1bc3b0562c147df7a1a))
 
 ## [5.4.1](https://github.com/richwklein/agingdeveloper/compare/5.4.0...5.4.1) (2025-08-25)
 
 ### Miscellaneous Changes
 
-* Quote of the week for 2025-08-25 ([#779](https://github.com/richwklein/agingdeveloper/issues/779)) ([f322d90](https://github.com/richwklein/agingdeveloper/commit/f322d902f7258053ae639e85e7f0380942c50a27))
+- Quote of the week for 2025-08-25 ([#779](https://github.com/richwklein/agingdeveloper/issues/779)) ([f322d90](https://github.com/richwklein/agingdeveloper/commit/f322d902f7258053ae639e85e7f0380942c50a27))
 
 ## [5.4.0](https://github.com/richwklein/agingdeveloper/compare/5.3.2...5.4.0) (2025-08-20)
 
 ### Miscellaneous Changes
 
-* Dependency upgrade ([#778](https://github.com/richwklein/agingdeveloper/issues/778)) ([d55785d](https://github.com/richwklein/agingdeveloper/commit/d55785df4bd2002cf4c0c94d2a71e6bf5b067af5))
+- Dependency upgrade ([#778](https://github.com/richwklein/agingdeveloper/issues/778)) ([d55785d](https://github.com/richwklein/agingdeveloper/commit/d55785df4bd2002cf4c0c94d2a71e6bf5b067af5))
 
 ## [5.3.2](https://github.com/richwklein/agingdeveloper/compare/5.3.1...5.3.2) (2025-08-18)
 
 ### Miscellaneous Changes
 
-* Quote of the week for 2025-08-18 ([#777](https://github.com/richwklein/agingdeveloper/issues/777)) ([841d31c](https://github.com/richwklein/agingdeveloper/commit/841d31cccdda9708c608f2e2c3518a4ee21786b3))
+- Quote of the week for 2025-08-18 ([#777](https://github.com/richwklein/agingdeveloper/issues/777)) ([841d31c](https://github.com/richwklein/agingdeveloper/commit/841d31cccdda9708c608f2e2c3518a4ee21786b3))
 
 ## [5.3.1](https://github.com/richwklein/agingdeveloper/compare/5.3.0...5.3.1) (2025-08-04)
 
 ### Miscellaneous Changes
 
-* Quote of the week 2025-08-04 ([#774](https://github.com/richwklein/agingdeveloper/issues/774)) ([b85fd4b](https://github.com/richwklein/agingdeveloper/commit/b85fd4b0b6fb621583d4a35689eb0386b3656dda))
+- Quote of the week 2025-08-04 ([#774](https://github.com/richwklein/agingdeveloper/issues/774)) ([b85fd4b](https://github.com/richwklein/agingdeveloper/commit/b85fd4b0b6fb621583d4a35689eb0386b3656dda))
 
 ## [5.3.0](https://github.com/richwklein/agingdeveloper/compare/5.2.11...5.3.0) (2025-07-29)
 
 ### Miscellaneous Changes
 
-* Ai prompt post ([#773](https://github.com/richwklein/agingdeveloper/issues/773)) ([236dea3](https://github.com/richwklein/agingdeveloper/commit/236dea349c5c296b9f619eb2f086f5fc239c8fd4))
+- Ai prompt post ([#773](https://github.com/richwklein/agingdeveloper/issues/773)) ([236dea3](https://github.com/richwklein/agingdeveloper/commit/236dea349c5c296b9f619eb2f086f5fc239c8fd4))
 
 ## [5.2.11](https://github.com/richwklein/agingdeveloper/compare/5.2.10...5.2.11) (2025-07-28)
 
 ### Miscellaneous Changes
 
-* Quote of the week: 2025-07-28 ([#772](https://github.com/richwklein/agingdeveloper/issues/772)) ([0e43e2e](https://github.com/richwklein/agingdeveloper/commit/0e43e2e81f2ad771c8e53ef83216d3ad209b3a0c))
+- Quote of the week: 2025-07-28 ([#772](https://github.com/richwklein/agingdeveloper/issues/772)) ([0e43e2e](https://github.com/richwklein/agingdeveloper/commit/0e43e2e81f2ad771c8e53ef83216d3ad209b3a0c))
 
 ## [5.2.10](https://github.com/richwklein/agingdeveloper/compare/5.2.9...5.2.10) (2025-07-21)
 
 ### Miscellaneous Changes
 
-* Quote of the week 2025-07-21 ([#771](https://github.com/richwklein/agingdeveloper/issues/771)) ([d666fc1](https://github.com/richwklein/agingdeveloper/commit/d666fc1e615a3d0fd57dfcb5257d628410b7bb4c))
+- Quote of the week 2025-07-21 ([#771](https://github.com/richwklein/agingdeveloper/issues/771)) ([d666fc1](https://github.com/richwklein/agingdeveloper/commit/d666fc1e615a3d0fd57dfcb5257d628410b7bb4c))
 
 ## [5.2.9](https://github.com/richwklein/agingdeveloper/compare/5.2.8...5.2.9) (2025-07-14)
 
 ### Miscellaneous Changes
 
-* Quote of the Week 2025-07-14 ([#770](https://github.com/richwklein/agingdeveloper/issues/770)) ([d4a3559](https://github.com/richwklein/agingdeveloper/commit/d4a3559fb5d829fc6e3304bc95ae96e036ce2d9f))
+- Quote of the Week 2025-07-14 ([#770](https://github.com/richwklein/agingdeveloper/issues/770)) ([d4a3559](https://github.com/richwklein/agingdeveloper/commit/d4a3559fb5d829fc6e3304bc95ae96e036ce2d9f))
 
 ## [5.2.8](https://github.com/richwklein/agingdeveloper/compare/5.2.7...5.2.8) (2025-07-09)
 
 ### Miscellaneous Changes
 
-* Quote of the week (2025-07-07) ([b7f95d6](https://github.com/richwklein/agingdeveloper/commit/b7f95d6133e1a70de59cf4508626ab54215c920b))
+- Quote of the week (2025-07-07) ([b7f95d6](https://github.com/richwklein/agingdeveloper/commit/b7f95d6133e1a70de59cf4508626ab54215c920b))
 
 ## [5.2.7](https://github.com/richwklein/agingdeveloper/compare/5.2.6...5.2.7) (2025-07-04)
 
 ### Miscellaneous Changes
 
-* Improve testing stance ([#726](https://github.com/richwklein/agingdeveloper/issues/726)) ([2a98cb0](https://github.com/richwklein/agingdeveloper/commit/2a98cb0c9140081521999195844f354eafcfa378))
+- Improve testing stance ([#726](https://github.com/richwklein/agingdeveloper/issues/726)) ([2a98cb0](https://github.com/richwklein/agingdeveloper/commit/2a98cb0c9140081521999195844f354eafcfa378))
 
 ## [5.2.6](https://github.com/richwklein/agingdeveloper/compare/5.2.5...5.2.6) (2025-06-30)
 
 ### Miscellaneous Changes
 
-* Quote of the Week for June 30th ([#768](https://github.com/richwklein/agingdeveloper/issues/768)) ([2e311c7](https://github.com/richwklein/agingdeveloper/commit/2e311c749631436ab81b6429f2203bcef57382e9))
+- Quote of the Week for June 30th ([#768](https://github.com/richwklein/agingdeveloper/issues/768)) ([2e311c7](https://github.com/richwklein/agingdeveloper/commit/2e311c749631436ab81b6429f2203bcef57382e9))
 
 ## [5.2.5](https://github.com/richwklein/agingdeveloper/compare/5.2.4...5.2.5) (2025-06-30)
 
 ### Miscellaneous Changes
 
-* Upgrade frameworks ([#769](https://github.com/richwklein/agingdeveloper/issues/769)) ([49ecac2](https://github.com/richwklein/agingdeveloper/commit/49ecac2dd2bf8bba2c83a6bdde1b5955a0a337c1))
-* Quote for 2025-06-23 ([#767](https://github.com/richwklein/agingdeveloper/issues/767)) ([4bdd1c0](https://github.com/richwklein/agingdeveloper/commit/4bdd1c037aaeac053668a8a36373265fde32c892))
+- Upgrade frameworks ([#769](https://github.com/richwklein/agingdeveloper/issues/769)) ([49ecac2](https://github.com/richwklein/agingdeveloper/commit/49ecac2dd2bf8bba2c83a6bdde1b5955a0a337c1))
+- Quote for 2025-06-23 ([#767](https://github.com/richwklein/agingdeveloper/issues/767)) ([4bdd1c0](https://github.com/richwklein/agingdeveloper/commit/4bdd1c037aaeac053668a8a36373265fde32c892))
 
 ## [5.2.4](https://github.com/richwklein/agingdeveloper/compare/5.2.3...5.2.4) (2025-06-09)
 
 ### Miscellaneous Changes
 
-* Quote of the week 2025-06-09 ([#766](https://github.com/richwklein/agingdeveloper/issues/766)) ([740fd8d](https://github.com/richwklein/agingdeveloper/commit/740fd8d055f4f2f969ac048f90c71bb32ec7a9c4))
+- Quote of the week 2025-06-09 ([#766](https://github.com/richwklein/agingdeveloper/issues/766)) ([740fd8d](https://github.com/richwklein/agingdeveloper/commit/740fd8d055f4f2f969ac048f90c71bb32ec7a9c4))
 
 ## [5.2.3](https://github.com/richwklein/agingdeveloper/compare/5.2.2...5.2.3) (2025-06-03)
 
 ### Miscellaneous Changes
 
-* Quote of the week for June 2nd, 2025 ([#765](https://github.com/richwklein/agingdeveloper/issues/765)) ([933a00b](https://github.com/richwklein/agingdeveloper/commit/933a00be11dda0e3de4beddc6e2992fed69ad9c6))
+- Quote of the week for June 2nd, 2025 ([#765](https://github.com/richwklein/agingdeveloper/issues/765)) ([933a00b](https://github.com/richwklein/agingdeveloper/commit/933a00be11dda0e3de4beddc6e2992fed69ad9c6))
 
 ## [5.2.2](https://github.com/richwklein/agingdeveloper/compare/5.2.1...5.2.2) (2025-05-26)
 
 ### Miscellaneous Changes
 
-* Quote of the week May 26th, 2025 ([#764](https://github.com/richwklein/agingdeveloper/issues/764)) ([961feec](https://github.com/richwklein/agingdeveloper/commit/961feec920c188b52f061431b61a34ce6c454560))
-* 2025-05-20 Quote ([#763](https://github.com/richwklein/agingdeveloper/issues/763)) ([8d32aae](https://github.com/richwklein/agingdeveloper/commit/8d32aae9248f8d15e0ca34fb10ffc999e1b123d6))
+- Quote of the week May 26th, 2025 ([#764](https://github.com/richwklein/agingdeveloper/issues/764)) ([961feec](https://github.com/richwklein/agingdeveloper/commit/961feec920c188b52f061431b61a34ce6c454560))
+- 2025-05-20 Quote ([#763](https://github.com/richwklein/agingdeveloper/issues/763)) ([8d32aae](https://github.com/richwklein/agingdeveloper/commit/8d32aae9248f8d15e0ca34fb10ffc999e1b123d6))
 
 ## [5.2.1](https://github.com/richwklein/agingdeveloper/compare/5.2.0...5.2.1) (2025-05-12)
 
 ### Miscellaneous Changes
 
-* Quote for the week of 05/12/2025 ([#762](https://github.com/richwklein/agingdeveloper/issues/762)) ([f462172](https://github.com/richwklein/agingdeveloper/commit/f4621721202cd80ee247df8de9eb8d20d99290fd))
+- Quote for the week of 05/12/2025 ([#762](https://github.com/richwklein/agingdeveloper/issues/762)) ([f462172](https://github.com/richwklein/agingdeveloper/commit/f4621721202cd80ee247df8de9eb8d20d99290fd))
 
 ## [5.2.0](https://github.com/richwklein/agingdeveloper/compare/5.1.5...5.2.0) (2025-05-10)
 
 ### Miscellaneous Changes
 
-* Fix validation errors in the RSS and Atom Feeds ([#761](https://github.com/richwklein/agingdeveloper/issues/761)) ([8611eb0](https://github.com/richwklein/agingdeveloper/commit/8611eb0a241ab536143f62da0982ca93a5dba4cb))
-* Bump feed from 4.2.2 to 5.0.0 ([#759](https://github.com/richwklein/agingdeveloper/issues/759)) ([00e2f9f](https://github.com/richwklein/agingdeveloper/commit/00e2f9f46c30976b60fa2a17fdd519f6ad8f3f11))
+- Fix validation errors in the RSS and Atom Feeds ([#761](https://github.com/richwklein/agingdeveloper/issues/761)) ([8611eb0](https://github.com/richwklein/agingdeveloper/commit/8611eb0a241ab536143f62da0982ca93a5dba4cb))
+- Bump feed from 4.2.2 to 5.0.0 ([#759](https://github.com/richwklein/agingdeveloper/issues/759)) ([00e2f9f](https://github.com/richwklein/agingdeveloper/commit/00e2f9f46c30976b60fa2a17fdd519f6ad8f3f11))
 
 ## [5.1.5](https://github.com/richwklein/agingdeveloper/compare/5.1.4...5.1.5) (2025-05-05)
 
 ### Miscellaneous Changes
 
-* Quote for the week of May 5th ([#758](https://github.com/richwklein/agingdeveloper/issues/758)) ([943f68b](https://github.com/richwklein/agingdeveloper/commit/943f68b942c326ccac2c4ffb957af06f8206373a))
-* Quote for the week of 2025-04-13 ([#757](https://github.com/richwklein/agingdeveloper/issues/757)) ([e84e3fb](https://github.com/richwklein/agingdeveloper/commit/e84e3fbfc8b879e4a78f8a5ae1568cb41f6ca2f0))
+- Quote for the week of May 5th ([#758](https://github.com/richwklein/agingdeveloper/issues/758)) ([943f68b](https://github.com/richwklein/agingdeveloper/commit/943f68b942c326ccac2c4ffb957af06f8206373a))
+- Quote for the week of 2025-04-13 ([#757](https://github.com/richwklein/agingdeveloper/issues/757)) ([e84e3fb](https://github.com/richwklein/agingdeveloper/commit/e84e3fbfc8b879e4a78f8a5ae1568cb41f6ca2f0))
 
 ## [5.1.4](https://github.com/richwklein/agingdeveloper/compare/5.1.3...5.1.4) (2025-03-31)
 
 ### Miscellaneous Changes
 
-* Quote of the week 2025-03-31 ([#756](https://github.com/richwklein/agingdeveloper/issues/756)) ([083f86e](https://github.com/richwklein/agingdeveloper/commit/083f86e392b4b363b046ae2006fd4dfd42703242))
+- Quote of the week 2025-03-31 ([#756](https://github.com/richwklein/agingdeveloper/issues/756)) ([083f86e](https://github.com/richwklein/agingdeveloper/commit/083f86e392b4b363b046ae2006fd4dfd42703242))
 
 ## [5.1.3](https://github.com/richwklein/agingdeveloper/compare/5.1.2...5.1.3) (2025-03-26)
 
 ### Miscellaneous Changes
 
-* Quote for the week of 03/24 ([#755](https://github.com/richwklein/agingdeveloper/issues/755)) ([f9edcac](https://github.com/richwklein/agingdeveloper/commit/f9edcaceb53443cac64770336283c64250858365))
+- Quote for the week of 03/24 ([#755](https://github.com/richwklein/agingdeveloper/issues/755)) ([f9edcac](https://github.com/richwklein/agingdeveloper/commit/f9edcaceb53443cac64770336283c64250858365))
 
 ## [5.1.2](https://github.com/richwklein/agingdeveloper/compare/5.1.1...5.1.2) (2025-03-17)
 
 ### Miscellaneous Changes
 
-* Quote for the week of 2025-03-17 ([#754](https://github.com/richwklein/agingdeveloper/issues/754)) ([4df7c20](https://github.com/richwklein/agingdeveloper/commit/4df7c2063caed69f1d3d61c85a1b582b5ee8b4ff))
+- Quote for the week of 2025-03-17 ([#754](https://github.com/richwklein/agingdeveloper/issues/754)) ([4df7c20](https://github.com/richwklein/agingdeveloper/commit/4df7c2063caed69f1d3d61c85a1b582b5ee8b4ff))
 
 ## [5.1.1](https://github.com/richwklein/agingdeveloper/compare/5.0.1...5.1.1) (2025-03-15)
 
 ### Miscellaneous Changes
 
-* Create the post slug based on the file path ([#753](https://github.com/richwklein/agingdeveloper/issues/753)) ([2e7d777](https://github.com/richwklein/agingdeveloper/commit/2e7d7771577427c790e45ba6cb757c1fce5c69cc))
-* Add an LLM disclaimer widget ([#752](https://github.com/richwklein/agingdeveloper/issues/752)) ([00513c2](https://github.com/richwklein/agingdeveloper/commit/00513c25f1a9c97837a1e5478304e66c80a08554))
+- Create the post slug based on the file path ([#753](https://github.com/richwklein/agingdeveloper/issues/753)) ([2e7d777](https://github.com/richwklein/agingdeveloper/commit/2e7d7771577427c790e45ba6cb757c1fce5c69cc))
+- Add an LLM disclaimer widget ([#752](https://github.com/richwklein/agingdeveloper/issues/752)) ([00513c2](https://github.com/richwklein/agingdeveloper/commit/00513c25f1a9c97837a1e5478304e66c80a08554))
 
 ## [5.0.1](https://github.com/richwklein/agingdeveloper/compare/5.0.0...5.0.1) (2025-03-02)
 
 ### Miscellaneous Changes
 
-* Quote for the week of 03/03 ([#751](https://github.com/richwklein/agingdeveloper/issues/751)) ([efb71f0](https://github.com/richwklein/agingdeveloper/commit/efb71f0f0ebb5474c3eceeaf0ee9d10fa5f0a203))
+- Quote for the week of 03/03 ([#751](https://github.com/richwklein/agingdeveloper/issues/751)) ([efb71f0](https://github.com/richwklein/agingdeveloper/commit/efb71f0f0ebb5474c3eceeaf0ee9d10fa5f0a203))
 
 ## [5.0.0](https://github.com/richwklein/agingdeveloper/compare/4.3.2...5.0.0) (2025-02-27)
 
 ### Miscellaneous Changes
 
-* Upgrade astro and tailwind ([#749](https://github.com/richwklein/agingdeveloper/issues/749)) ([64e91ae](https://github.com/richwklein/agingdeveloper/commit/64e91ae3e5898f6e1c3f512c04411361a59bc218))
+- Upgrade astro and tailwind ([#749](https://github.com/richwklein/agingdeveloper/issues/749)) ([64e91ae](https://github.com/richwklein/agingdeveloper/commit/64e91ae3e5898f6e1c3f512c04411361a59bc218))
 
 ## [4.3.2](https://github.com/richwklein/agingdeveloper/compare/4.3.1...4.3.2) (2025-02-24)
 
 ### Miscellaneous Changes
 
-* Quote for the week of 02/24/2025 ([#746](https://github.com/richwklein/agingdeveloper/issues/746)) ([1343bc0](https://github.com/richwklein/agingdeveloper/commit/1343bc09944a3c98a62a7055acfc1390bde70304))
-* Quote for the week of 2025-02-17 ([#744](https://github.com/richwklein/agingdeveloper/issues/744)) ([2d905a5](https://github.com/richwklein/agingdeveloper/commit/2d905a5860a68ac34df537ad36db86ee58e3d195))
+- Quote for the week of 02/24/2025 ([#746](https://github.com/richwklein/agingdeveloper/issues/746)) ([1343bc0](https://github.com/richwklein/agingdeveloper/commit/1343bc09944a3c98a62a7055acfc1390bde70304))
+- Quote for the week of 2025-02-17 ([#744](https://github.com/richwklein/agingdeveloper/issues/744)) ([2d905a5](https://github.com/richwklein/agingdeveloper/commit/2d905a5860a68ac34df537ad36db86ee58e3d195))
 
 ## [4.3.1](https://github.com/richwklein/agingdeveloper/compare/4.3.0...4.3.1) (2025-02-11)
 
 ### Miscellaneous Changes
 
-* Add this weeks quote ([#743](https://github.com/richwklein/agingdeveloper/issues/743)) ([8f5ac50](https://github.com/richwklein/agingdeveloper/commit/8f5ac505b83825e050e06be350e590a0b58712a1))
+- Add this weeks quote ([#743](https://github.com/richwklein/agingdeveloper/issues/743)) ([8f5ac50](https://github.com/richwklein/agingdeveloper/commit/8f5ac505b83825e050e06be350e590a0b58712a1))
 
 ## [4.3.0](https://github.com/richwklein/agingdeveloper/compare/4.2.9...4.3.0) (2025-02-01)
 
 ### Miscellaneous Changes
 
-* New article on my git-cleanup script ([#739](https://github.com/richwklein/agingdeveloper/issues/739)) ([296808b](https://github.com/richwklein/agingdeveloper/commit/296808bcf64c0170ce8a7f4bd62176fad30afc1b))
+- New article on my git-cleanup script ([#739](https://github.com/richwklein/agingdeveloper/issues/739)) ([296808b](https://github.com/richwklein/agingdeveloper/commit/296808bcf64c0170ce8a7f4bd62176fad30afc1b))
 
 ## [4.2.9](https://github.com/richwklein/agingdeveloper/compare/4.2.8...4.2.9) (2025-01-29)
 
 ### Miscellaneous Changes
 
-* Quote for the week ending February 1st ([#735](https://github.com/richwklein/agingdeveloper/issues/735)) ([bd2a4d1](https://github.com/richwklein/agingdeveloper/commit/bd2a4d10f2b043481fc33d377d849161ec30976c))
+- Quote for the week ending February 1st ([#735](https://github.com/richwklein/agingdeveloper/issues/735)) ([bd2a4d1](https://github.com/richwklein/agingdeveloper/commit/bd2a4d10f2b043481fc33d377d849161ec30976c))
 
 ## [4.2.8](https://github.com/richwklein/agingdeveloper/compare/4.2.7...4.2.8) (2025-01-19)
 
 ### Miscellaneous Changes
 
-* Quote for this week ([#734](https://github.com/richwklein/agingdeveloper/issues/734)) ([ce97a9b](https://github.com/richwklein/agingdeveloper/commit/ce97a9b81c369cc87f926728fb0c781c9d4f8dfa))
+- Quote for this week ([#734](https://github.com/richwklein/agingdeveloper/issues/734)) ([ce97a9b](https://github.com/richwklein/agingdeveloper/commit/ce97a9b81c369cc87f926728fb0c781c9d4f8dfa))
 
 ## [4.2.7](https://github.com/richwklein/agingdeveloper/compare/4.2.6...4.2.7) (2025-01-17)
 
 ### Miscellaneous Changes
 
-* Do not run the license report on forks ([#732](https://github.com/richwklein/agingdeveloper/issues/732)) ([29f9962](https://github.com/richwklein/agingdeveloper/commit/29f9962f46c11cff852c593d6cca6b25a94aece0))
+- Do not run the license report on forks ([#732](https://github.com/richwklein/agingdeveloper/issues/732)) ([29f9962](https://github.com/richwklein/agingdeveloper/commit/29f9962f46c11cff852c593d6cca6b25a94aece0))
 
 ## [4.2.6](https://github.com/richwklein/agingdeveloper/compare/4.2.5...4.2.6) (2025-01-17)
 
 ### Miscellaneous Changes
 
-* Bump the vitest group across 1 directory with 2 updates ([#731](https://github.com/richwklein/agingdeveloper/issues/731)) ([61b4e46](https://github.com/richwklein/agingdeveloper/commit/61b4e4614fe47f1e5cc82df708abce02970e9de2))
+- Bump the vitest group across 1 directory with 2 updates ([#731](https://github.com/richwklein/agingdeveloper/issues/731)) ([61b4e46](https://github.com/richwklein/agingdeveloper/commit/61b4e4614fe47f1e5cc82df708abce02970e9de2))
 
 ## [4.2.5](https://github.com/richwklein/agingdeveloper/compare/4.2.4...4.2.5) (2025-01-13)
 
 ### Miscellaneous Changes
 
-* Quote for the week of 2024-01-13 ([#729](https://github.com/richwklein/agingdeveloper/issues/729)) ([8bb1b35](https://github.com/richwklein/agingdeveloper/commit/8bb1b355cc04c5eb7fd8386f8dee96e508a63876))
+- Quote for the week of 2024-01-13 ([#729](https://github.com/richwklein/agingdeveloper/issues/729)) ([8bb1b35](https://github.com/richwklein/agingdeveloper/commit/8bb1b355cc04c5eb7fd8386f8dee96e508a63876))
 
 ## [4.2.4](https://github.com/richwklein/agingdeveloper/compare/4.2.3...4.2.4) (2025-01-06)
 
 ### Miscellaneous Changes
 
-* Add this weeks quote ([57d3991](https://github.com/richwklein/agingdeveloper/commit/57d39914210800e151d769d58f246237bebbf243))
+- Add this weeks quote ([57d3991](https://github.com/richwklein/agingdeveloper/commit/57d39914210800e151d769d58f246237bebbf243))
 
 ## [4.2.3](https://github.com/richwklein/agingdeveloper/compare/4.2.2...4.2.3) (2024-12-30)
 
 ### Miscellaneous Changes
 
-* Quote of the week ([#728](https://github.com/richwklein/agingdeveloper/issues/728)) ([ca5c771](https://github.com/richwklein/agingdeveloper/commit/ca5c7716771acd852ed67a19acb76355469fe164))
+- Quote of the week ([#728](https://github.com/richwklein/agingdeveloper/issues/728)) ([ca5c771](https://github.com/richwklein/agingdeveloper/commit/ca5c7716771acd852ed67a19acb76355469fe164))
 
 ## [4.2.2](https://github.com/richwklein/agingdeveloper/compare/4.2.1...4.2.2) (2024-12-30)
 
 ### Miscellaneous Changes
 
-* patch version bump ([8a71294](https://github.com/richwklein/agingdeveloper/commit/8a71294572eb953f1c052f6d331bfe17812acb56))
+- patch version bump ([8a71294](https://github.com/richwklein/agingdeveloper/commit/8a71294572eb953f1c052f6d331bfe17812acb56))
 
 ## [4.2.1](https://github.com/richwklein/agingdeveloper/compare/4.2.0...4.2.1) (2024-12-23)
 
 ### Miscellaneous Changes
 
-* Quote for this week ([#727](https://github.com/richwklein/agingdeveloper/issues/727)) ([b3d119e](https://github.com/richwklein/agingdeveloper/commit/b3d119e8b98b91924fe404e46e8439bbcff123a7))
+- Quote for this week ([#727](https://github.com/richwklein/agingdeveloper/issues/727)) ([b3d119e](https://github.com/richwklein/agingdeveloper/commit/b3d119e8b98b91924fe404e46e8439bbcff123a7))
 
 ## [4.2.0](https://github.com/richwklein/agingdeveloper/compare/4.1.2...4.2.0) (2024-12-21)
 
 ### Miscellaneous Changes
 
-* Add a typeahead search to the 404 page to help find what they are lookking for ([#725](https://github.com/richwklein/agingdeveloper/issues/725)) ([b01d59a](https://github.com/richwklein/agingdeveloper/commit/b01d59a3232eb739ab1f66e6c4325185463021aa))
+- Add a typeahead search to the 404 page to help find what they are lookking for ([#725](https://github.com/richwklein/agingdeveloper/issues/725)) ([b01d59a](https://github.com/richwklein/agingdeveloper/commit/b01d59a3232eb739ab1f66e6c4325185463021aa))
 
 ## [4.1.2](https://github.com/richwklein/agingdeveloper/compare/4.1.1...4.1.2) (2024-12-18)
 
 ### Miscellaneous Changes
 
-* Add a github workflow to report licenses ([#724](https://github.com/richwklein/agingdeveloper/issues/724)) ([59c96e1](https://github.com/richwklein/agingdeveloper/commit/59c96e16beb9f3416f796e9d690aaf0117d10fa5))
+- Add a github workflow to report licenses ([#724](https://github.com/richwklein/agingdeveloper/issues/724)) ([59c96e1](https://github.com/richwklein/agingdeveloper/commit/59c96e16beb9f3416f796e9d690aaf0117d10fa5))
 
 ## [4.1.1](https://github.com/richwklein/agingdeveloper/compare/4.1.0...4.1.1) (2024-12-16)
 
 ### Miscellaneous Changes
 
-* Quote for the week ([#722](https://github.com/richwklein/agingdeveloper/issues/722)) ([4193ccb](https://github.com/richwklein/agingdeveloper/commit/4193ccb6af64bd2c2feec5435e2ed680e2c5c2d8))
+- Quote for the week ([#722](https://github.com/richwklein/agingdeveloper/issues/722)) ([4193ccb](https://github.com/richwklein/agingdeveloper/commit/4193ccb6af64bd2c2feec5435e2ed680e2c5c2d8))
 
 ## [4.1.0](https://github.com/richwklein/agingdeveloper/compare/4.0.0...4.1.0) (2024-12-11)
 
 ### Miscellaneous Changes
 
-* Create a virtual quote board ([#715](https://github.com/richwklein/agingdeveloper/issues/715)) ([ee45f0d](https://github.com/richwklein/agingdeveloper/commit/ee45f0d8a1c1a4f9a3bb74ebccd91670a3d2a727))
+- Create a virtual quote board ([#715](https://github.com/richwklein/agingdeveloper/issues/715)) ([ee45f0d](https://github.com/richwklein/agingdeveloper/commit/ee45f0d8a1c1a4f9a3bb74ebccd91670a3d2a727))
 
 ## [4.0.0](https://github.com/richwklein/agingdeveloper/compare/3.5.3...4.0.0) (2024-12-10)
 
 ### Miscellaneous Changes
 
-* Update Astro to version 5.0.* ([#717](https://github.com/richwklein/agingdeveloper/issues/717)) ([faffed1](https://github.com/richwklein/agingdeveloper/commit/faffed15117c20655c4a24af6465736b32d9b3a9))
+- Update Astro to version 5.0.\* ([#717](https://github.com/richwklein/agingdeveloper/issues/717)) ([faffed1](https://github.com/richwklein/agingdeveloper/commit/faffed15117c20655c4a24af6465736b32d9b3a9))
 
 ## [3.5.3](https://github.com/richwklein/agingdeveloper/compare/3.5.2...3.5.3) (2024-11-21)
 
 ### Miscellaneous Changes
 
-* Update dependencies to pick up typescript / eslint bug fix ([#714](https://github.com/richwklein/agingdeveloper/issues/714)) ([9ffb9de](https://github.com/richwklein/agingdeveloper/commit/9ffb9ded6ec5bc49301d69d2aee4e3e393e870f7))
+- Update dependencies to pick up typescript / eslint bug fix ([#714](https://github.com/richwklein/agingdeveloper/issues/714)) ([9ffb9de](https://github.com/richwklein/agingdeveloper/commit/9ffb9ded6ec5bc49301d69d2aee4e3e393e870f7))
 
 ## [3.5.2](https://github.com/richwklein/agingdeveloper/compare/3.5.1...3.5.2) (2024-11-16)
 
 ### Miscellaneous Changes
 
-* Minor Tweaks ([#713](https://github.com/richwklein/agingdeveloper/issues/713)) ([514a23a](https://github.com/richwklein/agingdeveloper/commit/514a23a898b4e0dc96740b9b38565dff27052ae9))
+- Minor Tweaks ([#713](https://github.com/richwklein/agingdeveloper/issues/713)) ([514a23a](https://github.com/richwklein/agingdeveloper/commit/514a23a898b4e0dc96740b9b38565dff27052ae9))
 
 ## [3.5.1](https://github.com/richwklein/agingdeveloper/compare/3.5.0...3.5.1) (2024-11-03)
 
 ### Miscellaneous Changes
 
-* Article on using Umami to track events on the site ([#712](https://github.com/richwklein/agingdeveloper/issues/712)) ([c42bdc9](https://github.com/richwklein/agingdeveloper/commit/c42bdc9a5cb961ae2ee04ef3cbc831f88ec7f2bc))
+- Article on using Umami to track events on the site ([#712](https://github.com/richwklein/agingdeveloper/issues/712)) ([c42bdc9](https://github.com/richwklein/agingdeveloper/commit/c42bdc9a5cb961ae2ee04ef3cbc831f88ec7f2bc))
 
 ## [3.5.0](https://github.com/richwklein/agingdeveloper/compare/3.4.2...3.5.0) (2024-11-03)
 
 ### Miscellaneous Changes
 
-* improve layout performance ([#711](https://github.com/richwklein/agingdeveloper/issues/711)) ([7fb7acd](https://github.com/richwklein/agingdeveloper/commit/7fb7acdce6ee580a127b30c8135b4e1af5867e54))
+- improve layout performance ([#711](https://github.com/richwklein/agingdeveloper/issues/711)) ([7fb7acd](https://github.com/richwklein/agingdeveloper/commit/7fb7acdce6ee580a127b30c8135b4e1af5867e54))
 
 ## [3.4.2](https://github.com/richwklein/agingdeveloper/compare/3.4.1...3.4.2) (2024-11-02)
 
 ### Miscellaneous Changes
 
-* Add an alert component that can be used in posts ([#710](https://github.com/richwklein/agingdeveloper/issues/710)) ([3f7097b](https://github.com/richwklein/agingdeveloper/commit/3f7097b6175db58bfaf4857244746ce3049d93f9))
+- Add an alert component that can be used in posts ([#710](https://github.com/richwklein/agingdeveloper/issues/710)) ([3f7097b](https://github.com/richwklein/agingdeveloper/commit/3f7097b6175db58bfaf4857244746ce3049d93f9))
 
 ## [3.4.1](https://github.com/richwklein/agingdeveloper/compare/3.4.0...3.4.1) (2024-09-06)
 
 ### Miscellaneous Changes
 
-* Improve linting stance by adding a11y ([#709](https://github.com/richwklein/agingdeveloper/issues/709)) ([adfd0d9](https://github.com/richwklein/agingdeveloper/commit/adfd0d9b7bbadf6642a92563bd27e2d323185cd0))
-* Minor fixes for crawling and lighthouse issues ([#707](https://github.com/richwklein/agingdeveloper/issues/707)) ([096b38b](https://github.com/richwklein/agingdeveloper/commit/096b38b4758971d2bed820fd6454ca651f193d09))
-* deal with trailingslash inconsistency ([#706](https://github.com/richwklein/agingdeveloper/issues/706)) ([f7f0b58](https://github.com/richwklein/agingdeveloper/commit/f7f0b5887fb382e51e8242a2c960ee827906f9e5))
+- Improve linting stance by adding a11y ([#709](https://github.com/richwklein/agingdeveloper/issues/709)) ([adfd0d9](https://github.com/richwklein/agingdeveloper/commit/adfd0d9b7bbadf6642a92563bd27e2d323185cd0))
+- Minor fixes for crawling and lighthouse issues ([#707](https://github.com/richwklein/agingdeveloper/issues/707)) ([096b38b](https://github.com/richwklein/agingdeveloper/commit/096b38b4758971d2bed820fd6454ca651f193d09))
+- deal with trailingslash inconsistency ([#706](https://github.com/richwklein/agingdeveloper/issues/706)) ([f7f0b58](https://github.com/richwklein/agingdeveloper/commit/f7f0b5887fb382e51e8242a2c960ee827906f9e5))
 
 ## [3.4.0](https://github.com/richwklein/agingdeveloper/compare/3.3.0...3.4.0) (2024-08-20)
 
 ### Miscellaneous Changes
 
-* Add popular articles component ([bc06c63](https://github.com/richwklein/agingdeveloper/commit/bc06c636b6a7eb79a0f20b1b52992bb068ddbbdc))
+- Add popular articles component ([bc06c63](https://github.com/richwklein/agingdeveloper/commit/bc06c636b6a7eb79a0f20b1b52992bb068ddbbdc))
 
 ## [3.3.0](https://github.com/richwklein/agingdeveloper/compare/3.2.0...3.3.0) (2024-08-18)
 
 ### Miscellaneous Changes
 
-* Recent articles component ([#705](https://github.com/richwklein/agingdeveloper/issues/705)) ([894c04f](https://github.com/richwklein/agingdeveloper/commit/894c04f09a93333918843549ba016a6d20ece790))
+- Recent articles component ([#705](https://github.com/richwklein/agingdeveloper/issues/705)) ([894c04f](https://github.com/richwklein/agingdeveloper/commit/894c04f09a93333918843549ba016a6d20ece790))
 
 ## [3.2.0](https://github.com/richwklein/agingdeveloper/compare/3.1.0...3.2.0) (2024-08-18)
 
 ### Miscellaneous Changes
 
-* Add support for related articles ([#703](https://github.com/richwklein/agingdeveloper/issues/703)) ([07314bc](https://github.com/richwklein/agingdeveloper/commit/07314bc434da316dc02057dbc24f571cc59cdbae))
+- Add support for related articles ([#703](https://github.com/richwklein/agingdeveloper/issues/703)) ([07314bc](https://github.com/richwklein/agingdeveloper/commit/07314bc434da316dc02057dbc24f571cc59cdbae))
 
 ## [3.1.0](https://github.com/richwklein/agingdeveloper/compare/3.0.2...3.1.0) (2024-08-18)
 
 ### Miscellaneous Changes
 
-* Fix for keybase file being missing and some settings cleanup ([#702](https://github.com/richwklein/agingdeveloper/issues/702)) ([de29254](https://github.com/richwklein/agingdeveloper/commit/de29254239158f13afeff4d9ffa7b8c54bf678a3))
+- Fix for keybase file being missing and some settings cleanup ([#702](https://github.com/richwklein/agingdeveloper/issues/702)) ([de29254](https://github.com/richwklein/agingdeveloper/commit/de29254239158f13afeff4d9ffa7b8c54bf678a3))
 
 ## [3.0.2](https://github.com/richwklein/agingdeveloper/compare/3.0.1...3.0.2) (2024-08-17)
 
 ### Miscellaneous Changes
 
-* Switch from overflow to scroll-gutter ([#701](https://github.com/richwklein/agingdeveloper/issues/701)) ([18a5171](https://github.com/richwklein/agingdeveloper/commit/18a5171bf6ec29e7abc35d2176d87f3b38c1aeae))
-* Bump @astrojs/check from 0.8.3 to 0.9.2 ([#696](https://github.com/richwklein/agingdeveloper/issues/696)) ([9f6e3f2](https://github.com/richwklein/agingdeveloper/commit/9f6e3f28f1bbac5c2d710b06475db303412663ff))
-* Bump the prettier group with 2 updates ([#695](https://github.com/richwklein/agingdeveloper/issues/695)) ([280f005](https://github.com/richwklein/agingdeveloper/commit/280f00593b796754abb5e22f2f5efb0bb24c736b))
+- Switch from overflow to scroll-gutter ([#701](https://github.com/richwklein/agingdeveloper/issues/701)) ([18a5171](https://github.com/richwklein/agingdeveloper/commit/18a5171bf6ec29e7abc35d2176d87f3b38c1aeae))
+- Bump @astrojs/check from 0.8.3 to 0.9.2 ([#696](https://github.com/richwklein/agingdeveloper/issues/696)) ([9f6e3f2](https://github.com/richwklein/agingdeveloper/commit/9f6e3f28f1bbac5c2d710b06475db303412663ff))
+- Bump the prettier group with 2 updates ([#695](https://github.com/richwklein/agingdeveloper/issues/695)) ([280f005](https://github.com/richwklein/agingdeveloper/commit/280f00593b796754abb5e22f2f5efb0bb24c736b))
 
 ## [3.0.1](https://github.com/richwklein/agingdeveloper/compare/3.0.0...3.0.1) (2024-08-17)
 
 ### Miscellaneous Changes
 
-* Split the coverage reporting from the testing ([#700](https://github.com/richwklein/agingdeveloper/issues/700)) ([2161f06](https://github.com/richwklein/agingdeveloper/commit/2161f0684062c223a897c0028c46fce4687ab1bc))
-* Update astro article with fixes ([#698](https://github.com/richwklein/agingdeveloper/issues/698)) ([1101cff](https://github.com/richwklein/agingdeveloper/commit/1101cffa12ec0d45f73d7cf2c6b505ae5f93bbae))
+- Split the coverage reporting from the testing ([#700](https://github.com/richwklein/agingdeveloper/issues/700)) ([2161f06](https://github.com/richwklein/agingdeveloper/commit/2161f0684062c223a897c0028c46fce4687ab1bc))
+- Update astro article with fixes ([#698](https://github.com/richwklein/agingdeveloper/issues/698)) ([1101cff](https://github.com/richwklein/agingdeveloper/commit/1101cffa12ec0d45f73d7cf2c6b505ae5f93bbae))
 
 ## [3.0.0](https://github.com/richwklein/agingdeveloper/compare/3.0.0-alpha1...3.0.0) (2024-08-16)
 
 ### Miscellaneous Changes
 
-* cut the full tag ([#697](https://github.com/richwklein/agingdeveloper/issues/697)) ([13f36e9](https://github.com/richwklein/agingdeveloper/commit/13f36e926a3a0e86ee53bb75d83d56e13163a762))
+- cut the full tag ([#697](https://github.com/richwklein/agingdeveloper/issues/697)) ([13f36e9](https://github.com/richwklein/agingdeveloper/commit/13f36e926a3a0e86ee53bb75d83d56e13163a762))
 
 ## [3.0.0-alpha1](https://github.com/richwklein/agingdeveloper/compare/2.3.1...3.0.0-alpha1) (2024-08-16)
 
 ### Miscellaneous Changes
 
-* Astro build ([#668](https://github.com/richwklein/agingdeveloper/issues/668)) ([12e888e](https://github.com/richwklein/agingdeveloper/commit/12e888ee22f6f6b513a49393b728938d80683ef6))
-* Bump actions/checkout from 4.1.6 to 4.1.7 in the github-actions group ([#663](https://github.com/richwklein/agingdeveloper/issues/663)) ([383cb23](https://github.com/richwklein/agingdeveloper/commit/383cb2300976d896ff97207264a23d7ac08fb4ee))
+- Astro build ([#668](https://github.com/richwklein/agingdeveloper/issues/668)) ([12e888e](https://github.com/richwklein/agingdeveloper/commit/12e888ee22f6f6b513a49393b728938d80683ef6))
+- Bump actions/checkout from 4.1.6 to 4.1.7 in the github-actions group ([#663](https://github.com/richwklein/agingdeveloper/issues/663)) ([383cb23](https://github.com/richwklein/agingdeveloper/commit/383cb2300976d896ff97207264a23d7ac08fb4ee))
 
 ## [2.3.1](https://github.com/richwklein/agingdeveloper/compare/2.3.0...2.3.1) (2024-06-08)
 
 ### Miscellaneous Changes
 
-* Launch command ([#662](https://github.com/richwklein/agingdeveloper/issues/662)) ([b112385](https://github.com/richwklein/agingdeveloper/commit/b1123855fb2dfd68223dc15d0d5c85381a076fa9))
-* Bump @testing-library/react from 15.0.7 to 16.0.0 ([#660](https://github.com/richwklein/agingdeveloper/issues/660)) ([0541725](https://github.com/richwklein/agingdeveloper/commit/054172504fa8eaa8751ee74a53b2607631aa4036))
-* Bump actions/checkout from 4.1.4 to 4.1.6 in the github-actions group across 1 directory ([#658](https://github.com/richwklein/agingdeveloper/issues/658)) ([61f7bd9](https://github.com/richwklein/agingdeveloper/commit/61f7bd9b1bc43f165994410bd3dcf7385a33bdce))
-* Bump actions/checkout from 4.1.3 to 4.1.4 in the github-actions group ([#655](https://github.com/richwklein/agingdeveloper/issues/655)) ([d4a29bf](https://github.com/richwklein/agingdeveloper/commit/d4a29bfff88a7485729434b9bb590e3b0ea0db50))
-* Bump actions/checkout from 4.1.2 to 4.1.3 in the github-actions group ([#652](https://github.com/richwklein/agingdeveloper/issues/652)) ([1fb7845](https://github.com/richwklein/agingdeveloper/commit/1fb784508a71260698dff259820595c624387782))
-* Bump @testing-library/react from 14.3.1 to 15.0.1 ([#651](https://github.com/richwklein/agingdeveloper/issues/651)) ([d30ee8d](https://github.com/richwklein/agingdeveloper/commit/d30ee8d5d754a44225a909e60308bcfe86f44705))
-* Bump the github-actions group with 1 update ([#647](https://github.com/richwklein/agingdeveloper/issues/647)) ([d45e8cd](https://github.com/richwklein/agingdeveloper/commit/d45e8cdd6f78b4398bb24b529b74dcf882787c37))
-* Bump slug from 8.2.3 to 9.0.0 ([#646](https://github.com/richwklein/agingdeveloper/issues/646)) ([75ea59a](https://github.com/richwklein/agingdeveloper/commit/75ea59a32874747079b0e21d8c3317e6920de5d7))
-* Bump the github-actions group with 1 update ([#644](https://github.com/richwklein/agingdeveloper/issues/644)) ([6643bcb](https://github.com/richwklein/agingdeveloper/commit/6643bcb60940b1f59e2f7ac6e725eb2cb5055c6a))
+- Launch command ([#662](https://github.com/richwklein/agingdeveloper/issues/662)) ([b112385](https://github.com/richwklein/agingdeveloper/commit/b1123855fb2dfd68223dc15d0d5c85381a076fa9))
+- Bump @testing-library/react from 15.0.7 to 16.0.0 ([#660](https://github.com/richwklein/agingdeveloper/issues/660)) ([0541725](https://github.com/richwklein/agingdeveloper/commit/054172504fa8eaa8751ee74a53b2607631aa4036))
+- Bump actions/checkout from 4.1.4 to 4.1.6 in the github-actions group across 1 directory ([#658](https://github.com/richwklein/agingdeveloper/issues/658)) ([61f7bd9](https://github.com/richwklein/agingdeveloper/commit/61f7bd9b1bc43f165994410bd3dcf7385a33bdce))
+- Bump actions/checkout from 4.1.3 to 4.1.4 in the github-actions group ([#655](https://github.com/richwklein/agingdeveloper/issues/655)) ([d4a29bf](https://github.com/richwklein/agingdeveloper/commit/d4a29bfff88a7485729434b9bb590e3b0ea0db50))
+- Bump actions/checkout from 4.1.2 to 4.1.3 in the github-actions group ([#652](https://github.com/richwklein/agingdeveloper/issues/652)) ([1fb7845](https://github.com/richwklein/agingdeveloper/commit/1fb784508a71260698dff259820595c624387782))
+- Bump @testing-library/react from 14.3.1 to 15.0.1 ([#651](https://github.com/richwklein/agingdeveloper/issues/651)) ([d30ee8d](https://github.com/richwklein/agingdeveloper/commit/d30ee8d5d754a44225a909e60308bcfe86f44705))
+- Bump the github-actions group with 1 update ([#647](https://github.com/richwklein/agingdeveloper/issues/647)) ([d45e8cd](https://github.com/richwklein/agingdeveloper/commit/d45e8cdd6f78b4398bb24b529b74dcf882787c37))
+- Bump slug from 8.2.3 to 9.0.0 ([#646](https://github.com/richwklein/agingdeveloper/issues/646)) ([75ea59a](https://github.com/richwklein/agingdeveloper/commit/75ea59a32874747079b0e21d8c3317e6920de5d7))
+- Bump the github-actions group with 1 update ([#644](https://github.com/richwklein/agingdeveloper/issues/644)) ([6643bcb](https://github.com/richwklein/agingdeveloper/commit/6643bcb60940b1f59e2f7ac6e725eb2cb5055c6a))
 
 ## [2.3.0](https://github.com/richwklein/agingdeveloper/compare/2.2.0...2.3.0) (2024-02-12)
 
 ### Miscellaneous Changes
 
-* Bump the package version to cut a new release ([bbeb795](https://github.com/richwklein/agingdeveloper/commit/bbeb795075593be4b5f96760cd2817fc1de35fac))
-* Bump eslint-plugin-simple-import-sort from 11.0.0 to 12.0.0 ([#641](https://github.com/richwklein/agingdeveloper/issues/641)) ([c36270a](https://github.com/richwklein/agingdeveloper/commit/c36270a17c808d3b7c69aedd4646040ecc9db83f))
-* New article on fixing exif dates in videos ([#640](https://github.com/richwklein/agingdeveloper/issues/640)) ([ab591cc](https://github.com/richwklein/agingdeveloper/commit/ab591cc854b5214ce0c40a652415b0a043edad83))
-* Fix where the page header overlaps content on small screens ([#639](https://github.com/richwklein/agingdeveloper/issues/639)) ([d5a6815](https://github.com/richwklein/agingdeveloper/commit/d5a6815f5574f45bbee081dc948f78588217cabf))
-* Bump eslint-plugin-simple-import-sort from 10.0.0 to 11.0.0 ([#638](https://github.com/richwklein/agingdeveloper/issues/638)) ([4946c44](https://github.com/richwklein/agingdeveloper/commit/4946c449299be7e16ec084a7403efa37024eacbd))
-* move code linting to a github action ([#635](https://github.com/richwklein/agingdeveloper/issues/635)) ([0408479](https://github.com/richwklein/agingdeveloper/commit/0408479edd9c5461cf9894a828f593b2075ff0bc))
+- Bump the package version to cut a new release ([bbeb795](https://github.com/richwklein/agingdeveloper/commit/bbeb795075593be4b5f96760cd2817fc1de35fac))
+- Bump eslint-plugin-simple-import-sort from 11.0.0 to 12.0.0 ([#641](https://github.com/richwklein/agingdeveloper/issues/641)) ([c36270a](https://github.com/richwklein/agingdeveloper/commit/c36270a17c808d3b7c69aedd4646040ecc9db83f))
+- New article on fixing exif dates in videos ([#640](https://github.com/richwklein/agingdeveloper/issues/640)) ([ab591cc](https://github.com/richwklein/agingdeveloper/commit/ab591cc854b5214ce0c40a652415b0a043edad83))
+- Fix where the page header overlaps content on small screens ([#639](https://github.com/richwklein/agingdeveloper/issues/639)) ([d5a6815](https://github.com/richwklein/agingdeveloper/commit/d5a6815f5574f45bbee081dc948f78588217cabf))
+- Bump eslint-plugin-simple-import-sort from 10.0.0 to 11.0.0 ([#638](https://github.com/richwklein/agingdeveloper/issues/638)) ([4946c44](https://github.com/richwklein/agingdeveloper/commit/4946c449299be7e16ec084a7403efa37024eacbd))
+- move code linting to a github action ([#635](https://github.com/richwklein/agingdeveloper/issues/635)) ([0408479](https://github.com/richwklein/agingdeveloper/commit/0408479edd9c5461cf9894a828f593b2075ff0bc))
 
 ## [2.2.0](https://github.com/richwklein/agingdeveloper/compare/2.1.3...2.2.0) (2024-01-27)
 
 ### Miscellaneous Changes
 
-* Re-implement the scroll to top behavior ([#634](https://github.com/richwklein/agingdeveloper/issues/634)) ([91dd62e](https://github.com/richwklein/agingdeveloper/commit/91dd62e1f29097b6812f05b3f6276cde3a8ef6d9))
+- Re-implement the scroll to top behavior ([#634](https://github.com/richwklein/agingdeveloper/issues/634)) ([91dd62e](https://github.com/richwklein/agingdeveloper/commit/91dd62e1f29097b6812f05b3f6276cde3a8ef6d9))
 
 ## [2.1.3](https://github.com/richwklein/agingdeveloper/compare/2.1.2...2.1.3) (2024-01-26)
 
 ### Miscellaneous Changes
 
-* Update package.json ([624db1e](https://github.com/richwklein/agingdeveloper/commit/624db1ed91896e3bbdae9d4ec33da66a026b1716))
-* Re-Feed support ([#633](https://github.com/richwklein/agingdeveloper/issues/633)) ([d4a98c8](https://github.com/richwklein/agingdeveloper/commit/d4a98c8f1737301149d99a048f9df16ede717220))
-* Add Breadcrumb rich schema ([#631](https://github.com/richwklein/agingdeveloper/issues/631)) ([c6870ff](https://github.com/richwklein/agingdeveloper/commit/c6870ff9c029ef889b7a2d41e240681f57e3df7a))
+- Update package.json ([624db1e](https://github.com/richwklein/agingdeveloper/commit/624db1ed91896e3bbdae9d4ec33da66a026b1716))
+- Re-Feed support ([#633](https://github.com/richwklein/agingdeveloper/issues/633)) ([d4a98c8](https://github.com/richwklein/agingdeveloper/commit/d4a98c8f1737301149d99a048f9df16ede717220))
+- Add Breadcrumb rich schema ([#631](https://github.com/richwklein/agingdeveloper/issues/631)) ([c6870ff](https://github.com/richwklein/agingdeveloper/commit/c6870ff9c029ef889b7a2d41e240681f57e3df7a))
 
 ## [2.1.2](https://github.com/richwklein/agingdeveloper/compare/2.1.1...2.1.2) (2024-01-24)
 
 ### Miscellaneous Changes
 
-* Fix unit tests ([1da8139](https://github.com/richwklein/agingdeveloper/commit/1da81390ca3cc14c663ce9195ee81d4aed317c4e))
-* Fix unit tests ([fecc711](https://github.com/richwklein/agingdeveloper/commit/fecc711dfb5b9d1454e4e1e0f06a1dda4a8dcac3))
-* Fix tests ([523a8bc](https://github.com/richwklein/agingdeveloper/commit/523a8bca9fe3cd4813b7913b2fcc04c2d54b1ff4))
-* Fix failing unit tests ([999b4e9](https://github.com/richwklein/agingdeveloper/commit/999b4e9f44dd27f01544ae98dbefd9454eb54652))
-* Update documentation ([e525af4](https://github.com/richwklein/agingdeveloper/commit/e525af4dfc372cc2b413b99d1fa84664893e1854))
-* Add article seo and semantic tags ([25c726b](https://github.com/richwklein/agingdeveloper/commit/25c726b26a9531c8b5360a17cfc3a15f39a70b07))
+- Fix unit tests ([1da8139](https://github.com/richwklein/agingdeveloper/commit/1da81390ca3cc14c663ce9195ee81d4aed317c4e))
+- Fix unit tests ([fecc711](https://github.com/richwklein/agingdeveloper/commit/fecc711dfb5b9d1454e4e1e0f06a1dda4a8dcac3))
+- Fix tests ([523a8bc](https://github.com/richwklein/agingdeveloper/commit/523a8bca9fe3cd4813b7913b2fcc04c2d54b1ff4))
+- Fix failing unit tests ([999b4e9](https://github.com/richwklein/agingdeveloper/commit/999b4e9f44dd27f01544ae98dbefd9454eb54652))
+- Update documentation ([e525af4](https://github.com/richwklein/agingdeveloper/commit/e525af4dfc372cc2b413b99d1fa84664893e1854))
+- Add article seo and semantic tags ([25c726b](https://github.com/richwklein/agingdeveloper/commit/25c726b26a9531c8b5360a17cfc3a15f39a70b07))
 
 ## [2.1.1](https://github.com/richwklein/agingdeveloper/compare/2.1.0...2.1.1) (2024-01-24)
 
 ### Miscellaneous Changes
 
-* Get profile seo working ([b45eecf](https://github.com/richwklein/agingdeveloper/commit/b45eecfecf2760814c7cbbe4a239afd958ec68f3))
-* wip ([e46fd92](https://github.com/richwklein/agingdeveloper/commit/e46fd9204708fbd55dff8c0490b8381d74d675dc))
+- Get profile seo working ([b45eecf](https://github.com/richwklein/agingdeveloper/commit/b45eecfecf2760814c7cbbe4a239afd958ec68f3))
+- wip ([e46fd92](https://github.com/richwklein/agingdeveloper/commit/e46fd9204708fbd55dff8c0490b8381d74d675dc))
 
 ## 2.1.0 (2024-01-22)
 
 ### Bug Fixes
 
-* implement the 404 page ([c9681e1](https://github.com/richwklein/agingdeveloper/commit/c9681e127a9fe9b058f70967d37d62fa1eda2c30))
+- implement the 404 page ([c9681e1](https://github.com/richwklein/agingdeveloper/commit/c9681e127a9fe9b058f70967d37d62fa1eda2c30))
 
 ### Miscellaneous Changes
 
-* Bump the github-actions group with 1 update ([7964953](https://github.com/richwklein/agingdeveloper/commit/79649535dd509ba683aa5d5ae072d05d36c3bc92))
-* Tag on package version change ([c74d94f](https://github.com/richwklein/agingdeveloper/commit/c74d94f9a8cd370fe493aa4cb8c72048c61e0bf2))
-* try setting the token via env ([080832a](https://github.com/richwklein/agingdeveloper/commit/080832a95a191fa13345fa5ac0e9b4d1fcec45d5))
-* fix workflow ([ffa5332](https://github.com/richwklein/agingdeveloper/commit/ffa53324408d4baff9ed84d0520adf40fb8ad5d7))
-* Fix linting and run docs ([8ee86f3](https://github.com/richwklein/agingdeveloper/commit/8ee86f3cf62597ad46640efcd8f8916432e116c0))
-* still trying to get coverage to work ([750e92d](https://github.com/richwklein/agingdeveloper/commit/750e92dcc03ec64fad94d6e503e68a01190ddd0b))
-* [skip ci] Update the github actions to try and make them work ([b2c2269](https://github.com/richwklein/agingdeveloper/commit/b2c22691528373ad51dab959ec00b4df1d78c6b6))
-* Add offline support and tweak code coverage action ([65f3086](https://github.com/richwklein/agingdeveloper/commit/65f3086565bc7926f877f1fa32f9fdda7ac65034))
-* Include a code coverage action ([0cf33d1](https://github.com/richwklein/agingdeveloper/commit/0cf33d10083499d4b81a049c035a9bcf45bc3818))
-* Add a github action to bump the package version and tag a release ([b99bd12](https://github.com/richwklein/agingdeveloper/commit/b99bd126189877920c2f4809773b35470b8b5156))
-* Update the repo config ([f04c570](https://github.com/richwklein/agingdeveloper/commit/f04c570b3a6f58a4d234303cf85884ffe80f0e0c))
-* Remove netlify.toml ([4e075d8](https://github.com/richwklein/agingdeveloper/commit/4e075d89493ff1414690290869efc00bd298f5e9))
-* remove package lock and fix description ([11150c6](https://github.com/richwklein/agingdeveloper/commit/11150c63364aff27871af36cb667626e32926bfe))
-* tweak the code blocks for better support ([9f8b74e](https://github.com/richwklein/agingdeveloper/commit/9f8b74e39d0fcfc5d57f6463728185b077f8051a))
-* Add another test to make sure the component handles a string child ([19a34a8](https://github.com/richwklein/agingdeveloper/commit/19a34a8e1f0229b4d565ea4836d0c00a49e5cf43))
-* Replace the rendering of code blocks with the prism-react-renderer component ([8c4e53e](https://github.com/richwklein/agingdeveloper/commit/8c4e53e639b14d33662e38e6675476a8732fee92))
-* fix snapshots ([b2eb6bb](https://github.com/richwklein/agingdeveloper/commit/b2eb6bb3d7e52a2b06e646d9c78de8b1b4a189ef))
-* upgrade icon dependency and remove lock file ([2cf8ed6](https://github.com/richwklein/agingdeveloper/commit/2cf8ed6c1a5d457f0ceca3d20a53580621693fad))
-* Bump the npm_and_yarn group across 1 directories with 2 updates ([db1c20d](https://github.com/richwklein/agingdeveloper/commit/db1c20d31e94652133805f5f00520b798aeac879))
-* Bump @mui/material from 5.15.3 to 5.15.4 ([8b21e0d](https://github.com/richwklein/agingdeveloper/commit/8b21e0d082deb95d820d280a57428f74a4797b1f))
-* fix casing ([c28e19c](https://github.com/richwklein/agingdeveloper/commit/c28e19ca245ad6f2702009e28b5928ffcba6db9d))
-* Drop the slug property from the site json ([194be3e](https://github.com/richwklein/agingdeveloper/commit/194be3eaad7d195d8ce621c51c0c612c3d496eba))
-* fix bad formatting by eslint ([a7f2667](https://github.com/richwklein/agingdeveloper/commit/a7f2667f93e7ddd8bf8615757f006969f5fc1a68))
-* Switch from using yaml to json for data ([32ef727](https://github.com/richwklein/agingdeveloper/commit/32ef7274d1275e6a7e392ed996f8ca998350b570))
-* remove unused import ([e499afc](https://github.com/richwklein/agingdeveloper/commit/e499afc16cdfb091a5f074ab7ca38a9d0696f85c))
-* Move redirects to a separate file ([7e8152f](https://github.com/richwklein/agingdeveloper/commit/7e8152fc99e8450569ebb7c97cd737e8a3cdad76))
-* Enforce the fields in the article frontmatter and use custom resolvers for defaults ([e7dccfa](https://github.com/richwklein/agingdeveloper/commit/e7dccfab51dd867a0c6e5706a7d5c2727f33c513))
-* Fix misplaced image ([41a739d](https://github.com/richwklein/agingdeveloper/commit/41a739d5e000c64bb39b24ad475e8091cc752e42))
-* Bump @mui/material from 5.15.2 to 5.15.3 ([7b25451](https://github.com/richwklein/agingdeveloper/commit/7b254513d7ccced8ce484a881b394ab6d93e260c))
-* Bump @mui/icons-material from 5.15.2 to 5.15.3 ([1175407](https://github.com/richwklein/agingdeveloper/commit/11754079d9976650bc139fa58906f5a5a4119852))
-* Bump @testing-library/jest-dom from 6.1.6 to 6.2.0 ([0213959](https://github.com/richwklein/agingdeveloper/commit/021395927742b3a7e6e7612f30074f20a82c4753))
-* Move keybase file so it is served ([51648c3](https://github.com/richwklein/agingdeveloper/commit/51648c3b62dde7c999433927b45e473c0b465ba4))
-* get analytics working??? ([972be2e](https://github.com/richwklein/agingdeveloper/commit/972be2ea0abfa0e4431c9d1239661cd374860ad6))
-* Bump @mui/material from 5.14.18 to 5.15.2 ([a9acd82](https://github.com/richwklein/agingdeveloper/commit/a9acd8229d6a53047f59d8dbff1f2e8c60c1316b))
-* Bump @emotion/react from 11.11.1 to 11.11.3 ([138c825](https://github.com/richwklein/agingdeveloper/commit/138c825ad8ab1f022f1e80a77fcb88550cb31219))
-* Fix issue with twitter cards ([67eb738](https://github.com/richwklein/agingdeveloper/commit/67eb738173c57c2b04e229b501afeb164e32e9b8))
-* Bump @testing-library/jest-dom from 6.1.4 to 6.1.6 ([d5ce224](https://github.com/richwklein/agingdeveloper/commit/d5ce224e7ba6469cf631efbd8a639cf82a8de000))
-* Bump @mui/icons-material from 5.14.18 to 5.15.2 ([bb40ea4](https://github.com/richwklein/agingdeveloper/commit/bb40ea41526397ee2cd37c1ad535d337217b26d5))
-* tweaks for the newest article ([20a667d](https://github.com/richwklein/agingdeveloper/commit/20a667de99bc0cea707bd3e851f85e0658db9c54))
-* fix syntax highlighting ([e389d02](https://github.com/richwklein/agingdeveloper/commit/e389d0208226f240c3a62061749afdfccc9f10c7))
-* pluralize ([a229811](https://github.com/richwklein/agingdeveloper/commit/a229811b746da36ac09b89d89b8c40b07e16e368))
-* Rebuild article ([045119b](https://github.com/richwklein/agingdeveloper/commit/045119b15a30af8d22ec56ad379351411eac75d5))
-* Add back in sitemap support ([ef4bf61](https://github.com/richwklein/agingdeveloper/commit/ef4bf619dfccfec33703e0c41409bbb5d9be14b2))
-* Add docs ([20c47c3](https://github.com/richwklein/agingdeveloper/commit/20c47c3a0ccbdffd85d7fde8d7c2991de7cd6e5c))
-* Add manifest and favicon ([f3b4f88](https://github.com/richwklein/agingdeveloper/commit/f3b4f8868a092bd18e8be5e01aa8e43da931934a))
-* Add author index page ([12a903a](https://github.com/richwklein/agingdeveloper/commit/12a903afc633e51bd662c78a2ea2af8adb007269))
-* Fix redirect rule ([2eb20d6](https://github.com/richwklein/agingdeveloper/commit/2eb20d620abd32fd7dff0c792a2346ada389704f))
-* fix up the redirects ([8cf801d](https://github.com/richwklein/agingdeveloper/commit/8cf801d266160dbefd12c521e1110a05bd75eec5))
-* Set up build file and redirects ([a64938d](https://github.com/richwklein/agingdeveloper/commit/a64938d5a9746f3856e5d2b66a3a314b3ec7d6d8))
-* Add a template for rendering author pages ([4080327](https://github.com/richwklein/agingdeveloper/commit/40803279cb58acf53ae3bbf75a92fe387772543f))
-* Add a button to navigate back ([10d82d1](https://github.com/richwklein/agingdeveloper/commit/10d82d1dff333ce7d466757058b533088ccd04f9))
-* Add google analytics ([b85fe58](https://github.com/richwklein/agingdeveloper/commit/b85fe58a7e4f1bcf06a3acb814bc4e1780cbc999))
-* Add robots.txt ([15b899f](https://github.com/richwklein/agingdeveloper/commit/15b899f7a01319ec294fecb70426a70d8573d6e5))
-* Fix unit tests ([4946347](https://github.com/richwklein/agingdeveloper/commit/4946347f2f4d0045007c794944d8ae28287e7cdd))
-* Fix unused imports ([e28650b](https://github.com/richwklein/agingdeveloper/commit/e28650b645989a2cfea5dfaf9d76d6df21a26068))
-* Bump gatsby version and tweaks ([7b1dc45](https://github.com/richwklein/agingdeveloper/commit/7b1dc45a5c61aca6aecc59e5c2740e47e162d5aa))
-* Add SocialButtonBar tests ([5bf8082](https://github.com/richwklein/agingdeveloper/commit/5bf80827880c1bfc6bde682091199f7d918bff0e))
-* Add todo for tests ([66bc467](https://github.com/richwklein/agingdeveloper/commit/66bc4671b7fe6614cd1126228a835805a15fae8b))
-* fix console errors and sort exports ([df833b9](https://github.com/richwklein/agingdeveloper/commit/df833b92e7ded7bdeeac4cddff984cca3383a1b4))
-* Get archive pages working ([1004ad3](https://github.com/richwklein/agingdeveloper/commit/1004ad3fc7e27c4304267d3525669b8476ba1d98))
-* Bump dependencies ([04d76b2](https://github.com/richwklein/agingdeveloper/commit/04d76b2bb5264ddffd54968db43d37649282f0f7))
-* Get build fixed ([87e1213](https://github.com/richwklein/agingdeveloper/commit/87e12130a6db9ec0b1c0f21d43627ce602a81e5c))
-* change frontmatter field to be "published" instead of "date".  Continue adding SEO. ([39255a2](https://github.com/richwklein/agingdeveloper/commit/39255a20e469e53b17a685da196739a006616780))
-* Get documentation in a good spot and all current pages rendering. ([0db8045](https://github.com/richwklein/agingdeveloper/commit/0db8045f617e2bc909630c76d9e3296ee90cd175))
-* more docstrings ([75a46d8](https://github.com/richwklein/agingdeveloper/commit/75a46d8715608614b024d6fcf0945ade92174435))
-* Adding more docstrings and getting the tag breadcrumb to work ([e525fd6](https://github.com/richwklein/agingdeveloper/commit/e525fd6c384ac43e07d3495d60fb3ac0a2b8da7f))
-* Add title block docs ([b2866a4](https://github.com/richwklein/agingdeveloper/commit/b2866a4c7b32270444cf1e2caf3f55ee96b1936f))
-* Add docs and tests to DisplayLimit ([3bd09a6](https://github.com/richwklein/agingdeveloper/commit/3bd09a655fd6898ed367387692594929dfe39668))
-* working on tests ([85414d6](https://github.com/richwklein/agingdeveloper/commit/85414d65e560a8195367bd9e1f57ac12a0eb7000))
-* Additional docs ([ddc6e1a](https://github.com/richwklein/agingdeveloper/commit/ddc6e1a36876f85bccfe1ed73b1bce2b27d4f41c))
-* test fixes ([a243454](https://github.com/richwklein/agingdeveloper/commit/a2434541c007aa5a23da4a2d506d20d78c11e870))
-* Start adding jsdocs and improving code ([4df88f0](https://github.com/richwklein/agingdeveloper/commit/4df88f078ac5fd29d7173dddff680a109b83d29e))
-* Get queries working for all the pages ([d9d479a](https://github.com/richwklein/agingdeveloper/commit/d9d479a681842fe55a954c9d9e28d4a7841ff8e7))
-* fix build ([6e6537b](https://github.com/richwklein/agingdeveloper/commit/6e6537bde1ac857d381ff41401033b2cc90d59e4))
-* fix build ([0bb9a82](https://github.com/richwklein/agingdeveloper/commit/0bb9a82d5ea3afe4224aca368ffa3bd88a10a438))
-* Get full height body working ([680f90d](https://github.com/richwklein/agingdeveloper/commit/680f90dc2c9b1ac8628aa7e474656fad464e7ab5))
-* Move around components ([9446777](https://github.com/richwklein/agingdeveloper/commit/9446777d24acf5f73fd744b75ab05fa5accadfa6))
-* Add fonts ([c307643](https://github.com/richwklein/agingdeveloper/commit/c3076435a93c0ebe5dd2d9422d4ff88201717ed8))
-* Increase the number of articles on the front page ([3882661](https://github.com/richwklein/agingdeveloper/commit/3882661710d8c9c90c6f6cdec6e9787ebfe39f7a))
-* add formatting back to ci build ([ee1f759](https://github.com/richwklein/agingdeveloper/commit/ee1f75945a7c6bee3b8a1c4820e601acf10b90c5))
-* tweak some styles ([f5a38b9](https://github.com/richwklein/agingdeveloper/commit/f5a38b9750002ec28d17ce5dbf38752e1026df94))
-* Reduce the blur on the hero image ([b089757](https://github.com/richwklein/agingdeveloper/commit/b089757894e762587e411edf6baa61fbc2ff4bf4))
-* Add the rest of the content to the branch ([b52b34b](https://github.com/richwklein/agingdeveloper/commit/b52b34bb6df04eec65fa1c8663f94654a79f9873))
-* fix author slug ([d734bd0](https://github.com/richwklein/agingdeveloper/commit/d734bd01af15b0af57abacd958c1c7b659437552))
-* Add TODOs ([b9769b7](https://github.com/richwklein/agingdeveloper/commit/b9769b79ebe60e744cfc50b6fc33bb2810646eec))
-* Get a hero block added to the home page ([e3e124d](https://github.com/richwklein/agingdeveloper/commit/e3e124dc49f07821f34072549cb4505832a434be))
-* Add time to read to the article template ([ccbc9e7](https://github.com/richwklein/agingdeveloper/commit/ccbc9e726071919e8455c3eb9eae5048b059afa3))
-* Get the avatar on the top bar ([7430995](https://github.com/richwklein/agingdeveloper/commit/74309955a4898cfbd50271cb2ed4305b8819fce1))
-* Improve TagBar and tests ([8083099](https://github.com/richwklein/agingdeveloper/commit/8083099ace617807face7b7025264a709d533bc3))
-* Try and get the ci working ([f2733c1](https://github.com/richwklein/agingdeveloper/commit/f2733c1a6e1b1e29db9b02f96fd7c058332a14ef))
-* Add another page ([aebed87](https://github.com/richwklein/agingdeveloper/commit/aebed8721b758abfab0659315d224be545d08930))
-* Add tagbar support ([2cd0e79](https://github.com/richwklein/agingdeveloper/commit/2cd0e796efa0c96cecff283eb56d37c4217f3904))
-* Add featured image support ([b537bc9](https://github.com/richwklein/agingdeveloper/commit/b537bc96ed0fe9d76e0e5f7d3f5253de99679dc2))
-* Move the title block to a component ([d06f47b](https://github.com/richwklein/agingdeveloper/commit/d06f47beece7abeff313f7cae6d9c050e69eecf1))
-* Article By Line ([d308c4a](https://github.com/richwklein/agingdeveloper/commit/d308c4a8e67b364d12d2c60833e8ce7253634d56))
-* more progress ([ae616a3](https://github.com/richwklein/agingdeveloper/commit/ae616a3e06be528f330d2b8479e2364fc8e2799d))
-* Adding tests ([59a3b86](https://github.com/richwklein/agingdeveloper/commit/59a3b8604f42395cf5014815aa5e8839fea63d04))
-* Switch basic testing to be snapshots ([c9cb1d4](https://github.com/richwklein/agingdeveloper/commit/c9cb1d41a8c58a1262c97e2be0a88400f6cf8401))
-* Start unit testing ([c94498a](https://github.com/richwklein/agingdeveloper/commit/c94498a765d0ce1bf23ecfe562a4610382bad35d))
-* initial work ([d122750](https://github.com/richwklein/agingdeveloper/commit/d122750869a75a4f430f32874ff62ddd8a7de9cc))
-* initial work ([a91123e](https://github.com/richwklein/agingdeveloper/commit/a91123e1bcecf8cd0852a9f624d6fb77cf24b5e1))
-* Starting over ([1d8e81d](https://github.com/richwklein/agingdeveloper/commit/1d8e81d2912bbd94c830851cdb977074194a6911))
-* Attempt to update node version used in build ([884771d](https://github.com/richwklein/agingdeveloper/commit/884771d342bd9b9dee18d25983081de696986451))
-* Bump eslint from 7.32.0 to 8.36.0 ([c2d6c27](https://github.com/richwklein/agingdeveloper/commit/c2d6c27db1b2d293803badc8abb6fa5f66ae13bc))
-* ignore cache directory and increase dependabot ([f876237](https://github.com/richwklein/agingdeveloper/commit/f876237828f73106af51477060319163a66ef7e4))
-* Bump gatsby-remark-images from 3.11.1 to 7.7.0 ([7116103](https://github.com/richwklein/agingdeveloper/commit/71161031ffe0a7dc24c1a2e56555432f9bb84e57))
-* Bump eslint from 7.32.0 to 8.36.0 ([d9f8b3f](https://github.com/richwklein/agingdeveloper/commit/d9f8b3f8641bbd8f48315bda06de92a18ceb73ee))
-* Bump gatsby-remark-prismjs from 3.13.0 to 7.7.0 ([bb1801b](https://github.com/richwklein/agingdeveloper/commit/bb1801b51414652382a3e9c42bdc7ef25a4d34bd))
-* Bump eslint-config-react-app from 6.0.0 to 7.0.1 ([f808db9](https://github.com/richwklein/agingdeveloper/commit/f808db93c9d04b317fb6fd36075a4dfdd9440edf))
-* Fix security mdx vulnerability ([1c63827](https://github.com/richwklein/agingdeveloper/commit/1c63827439f28fad63e4185377070a9620bab691))
-* Update index.md ([302193b](https://github.com/richwklein/agingdeveloper/commit/302193b95e5d9d7166a1358da86f457a62e7db4c))
-* Finish the article ([2d51803](https://github.com/richwklein/agingdeveloper/commit/2d51803c41eb68278df92eff162cb2eb48dde914))
-* article tweaks ([bc6292c](https://github.com/richwklein/agingdeveloper/commit/bc6292c1d0e35d6f3857b57e7361e0dfde248ae2))
-* disney post ([75a2701](https://github.com/richwklein/agingdeveloper/commit/75a270153024f3f75d6d39a0c1b59bdbe4f2b9a8))
-* Bump react from 17.0.2 to 18.1.0 ([59beabd](https://github.com/richwklein/agingdeveloper/commit/59beabd1aef9b5be0e32347f511c6c58b0ea7538))
-* drop versioning header ([5759624](https://github.com/richwklein/agingdeveloper/commit/5759624c1bc158c471dfe45f198d1dc8e5d04c28))
-* fixing ([af7dcf0](https://github.com/richwklein/agingdeveloper/commit/af7dcf0508b784a0080de7ad0c8243e5ca4352c5))
-* fix deps ([6a3e6d2](https://github.com/richwklein/agingdeveloper/commit/6a3e6d21038d442158a3696362958012251e4c24))
-* try and fix deps ([551c887](https://github.com/richwklein/agingdeveloper/commit/551c8873cc5218cb5cca85d0f936450bcdef6fdb))
-* force legacy dependency resolution ([0582865](https://github.com/richwklein/agingdeveloper/commit/058286558bfb7d3de58a696be20b4e8d9be3d3a3))
-* tweaking versions ([f5533cc](https://github.com/richwklein/agingdeveloper/commit/f5533ccbc61d3e8d88c0a91cdf68872c0d0ca731))
-* try newer version of node ([54aa22b](https://github.com/richwklein/agingdeveloper/commit/54aa22bf52e97d4b7760cdf9a524f3e78ba7580e))
-* try default node and ruby ([b5c897f](https://github.com/richwklein/agingdeveloper/commit/b5c897f7e5c21cd0341479fa35fb80d57471abc3))
-* New Article ([d5970e6](https://github.com/richwklein/agingdeveloper/commit/d5970e682931e06ae5ae0165eb5a08f99a81a7db))
-* fix captialization ([922118e](https://github.com/richwklein/agingdeveloper/commit/922118edf6a4ac49d531796a13edbb95acc7c5d6))
-* tweak tense ([2c7680a](https://github.com/richwklein/agingdeveloper/commit/2c7680a2f852dab40a06b0dd0f0b0ec8c0598e26))
-* RSS Article ([b17c1cb](https://github.com/richwklein/agingdeveloper/commit/b17c1cb5f95659b569ece80eb575c27b16e9da9e))
-* Remove ignores ([369ef58](https://github.com/richwklein/agingdeveloper/commit/369ef58da2787b1f58f064ef339deb2f3918aa0a))
-* start on article ([237a64e](https://github.com/richwklein/agingdeveloper/commit/237a64e5066b8547ee85788a8928d495f2d6b0a0))
-* Upgrade to GitHub-native Dependabot ([ae596dd](https://github.com/richwklein/agingdeveloper/commit/ae596dd8f8f19b2c675b7beb78bdec1d917e6fa1))
-* Opt the website out of floc ([7189514](https://github.com/richwklein/agingdeveloper/commit/7189514f73d0fea569b31aef1f78245e8b075c08))
-* Make a PWA and add favicons ([98360af](https://github.com/richwklein/agingdeveloper/commit/98360af212fad92f504efca2c50125630efeb041))
-* upgrade minor versions ([720bbf7](https://github.com/richwklein/agingdeveloper/commit/720bbf7f5a8be2d8b7c25d44147b62288ade170d))
-* Add html to the rss feed ([1381c62](https://github.com/richwklein/agingdeveloper/commit/1381c628fff2e674e5a84345bd21bb8617cb0b17))
-* Update Dependencies ([3a080b0](https://github.com/richwklein/agingdeveloper/commit/3a080b0b36c4555080c2c34ef68cb45e6636d8a0))
-* Article on commit signing ([0d6d270](https://github.com/richwklein/agingdeveloper/commit/0d6d27092377ca425ea76ab20b90b2d74942b852))
-* Git Commit Signing Article ([791d3ff](https://github.com/richwklein/agingdeveloper/commit/791d3ff1408a73d6f3b7ffb3a76158f106f08928))
-* wip ([7698690](https://github.com/richwklein/agingdeveloper/commit/76986902ed954fcbf20ef922ece4ea88d5036229))
-* Fix publish date ([2772d2a](https://github.com/richwklein/agingdeveloper/commit/2772d2a887ee9d98b27a7631d9c3475b54a62551))
-* Article on virtual choir ([9bd913e](https://github.com/richwklein/agingdeveloper/commit/9bd913e624ba85438314894e437c59d60477824a))
-* Update packages to newest versions ([b01bf50](https://github.com/richwklein/agingdeveloper/commit/b01bf50dc66d568723f6d0bed883692519f567ad))
-* Bump eslint-config-react-app from 5.2.1 to 6.0.0 ([9a517c4](https://github.com/richwklein/agingdeveloper/commit/9a517c40e25b712135ab082b0c38030a977bcc13))
-* drop one of the links to other articles ([c76f6d8](https://github.com/richwklein/agingdeveloper/commit/c76f6d886875630336455b43ac6b9bb68199ebd1))
-* Samsung article with image tweaks ([1cce5d0](https://github.com/richwklein/agingdeveloper/commit/1cce5d0755377389d9f472f5655fe2acd86fdf94))
-* install npm globally ([aab2b65](https://github.com/richwklein/agingdeveloper/commit/aab2b6562649ca012153425f4d7282fee295e111))
-* Tweak the material-ui ([725769e](https://github.com/richwklein/agingdeveloper/commit/725769ef037168d67c33a9e7a042af36169c4e77))
-* Basic feed support without actual items yet ([7cd28eb](https://github.com/richwklein/agingdeveloper/commit/7cd28ebdd3995b8c4b63891b125453ba6e83f2b4))
-* Use more promises to parallelize more ([e1c8ef6](https://github.com/richwklein/agingdeveloper/commit/e1c8ef68ddf9eb47c60625c485a1740ef5148161))
-* remove content hashes from build ([9e06076](https://github.com/richwklein/agingdeveloper/commit/9e060764e699312585806f158a06b4713d8505d0))
-* rearrange plugin list ([671f99c](https://github.com/richwklein/agingdeveloper/commit/671f99c94cf897ad198fbcdcb5b28b7c56caa50f))
-* Enable build caching and switch to parallel page generation ([41b3cd4](https://github.com/richwklein/agingdeveloper/commit/41b3cd4718308cbb20439dfa8d112cb3ed5eb0ce))
-* fix typo ([0b997a4](https://github.com/richwklein/agingdeveloper/commit/0b997a4f2c210e6dc3329ea93c186637b6fab326))
-* Update article.js ([1956c26](https://github.com/richwklein/agingdeveloper/commit/1956c262476c533ad5cc9e28a9f1dcb9b239b864))
-* Update index.md ([fe7d36b](https://github.com/richwklein/agingdeveloper/commit/fe7d36b80a8b20e89c858983ee4044a4dfc0e52c))
-* new post on why aging developer ([0711f75](https://github.com/richwklein/agingdeveloper/commit/0711f7544c2081b104c911ebad6d703e13b32281))
-* fix description quoting on article ([219f3f9](https://github.com/richwklein/agingdeveloper/commit/219f3f9bb3e7316259528f695213d184bf3df900))
-* Add a description to the frontmatter for seo ([d9bed27](https://github.com/richwklein/agingdeveloper/commit/d9bed27972acaba5024c84c124c1b524ab8bed93))
-* ignore long line ([50c7a1f](https://github.com/richwklein/agingdeveloper/commit/50c7a1f6937e7f53c9d7f5a792c4bb4542435a49))
-* Create a custom 404 page ([204cc25](https://github.com/richwklein/agingdeveloper/commit/204cc255adc76a11a2d1777f8d538fbd20dd816c))
-* tweak the nav drawer ([4cb8400](https://github.com/richwklein/agingdeveloper/commit/4cb8400954c3213881f3e4dc2e441f3ccb56883e))
-* Fix badge causing mobile overflow issues ([2c32c67](https://github.com/richwklein/agingdeveloper/commit/2c32c67123745c2b5742b819faf081a38e145a7c))
-* New article on the author pages ([98e5ef4](https://github.com/richwklein/agingdeveloper/commit/98e5ef4abad0a42b78eab3e967690164188f556d))
-* Remove extra fragment ([16d37cd](https://github.com/richwklein/agingdeveloper/commit/16d37cd989dd0baf1e64200f117fa24ec798e07b))
-* Split tags back out ([d26f95d](https://github.com/richwklein/agingdeveloper/commit/d26f95dcd0656061b564e201f7506d79623d65e3))
-* tweak banner ([8a88049](https://github.com/richwklein/agingdeveloper/commit/8a880494d98a2a2c4a891271c5b006e0c63da7d2))
-* Finish landing the author pages ([af1d399](https://github.com/richwklein/agingdeveloper/commit/af1d3996bf513a23f7db05d16a56cbd2427c1fac))
-* Land most of the author pages work ([626131c](https://github.com/richwklein/agingdeveloper/commit/626131ce7b0f2356a9216d842416b17b178a0c4d))
-* tweaks on the way to landing author pages ([4e8beb6](https://github.com/richwklein/agingdeveloper/commit/4e8beb6e649e9f8e0a1dcee339daf70662cc7636))
-* tweak spacing more and add frontmatter settings ([bef98b6](https://github.com/richwklein/agingdeveloper/commit/bef98b6b6c94a0d5c9da4fc3d0567a40333ffb5b))
-* Adjust padding for responsive layout ([f87c9e4](https://github.com/richwklein/agingdeveloper/commit/f87c9e4525f888c5b527f142ecfc1dd60557c7dc))
-* Add new badge for articles newer than 14 days ([f3f3723](https://github.com/richwklein/agingdeveloper/commit/f3f3723de73d56e221c8008be613f1abac87ba36))
-* Add home to nav drawer ([a036dbb](https://github.com/richwklein/agingdeveloper/commit/a036dbbbd50e5b640a1c6ebe6d3d66247e438bd4))
-* Get an initial articles page done ([58200e6](https://github.com/richwklein/agingdeveloper/commit/58200e6aa7e03c608d2fcf2e7ad78ac6f085b2f4))
-* Style code using prismjs ([a499c6e](https://github.com/richwklein/agingdeveloper/commit/a499c6e727f7c10b0d029f0eb1fba249f0b8e0cf))
-* generalize the gridlist and button grids ([351b55a](https://github.com/richwklein/agingdeveloper/commit/351b55a9b06b1b4aa26e562e8e6271cb5e8734dc))
-* remove topbar padding ([82afb3e](https://github.com/richwklein/agingdeveloper/commit/82afb3eac770ba0e914c06bc80bab2c631fa782f))
-* drop breadcrumbs and reorganize ([df75fa9](https://github.com/richwklein/agingdeveloper/commit/df75fa979137231842786c68573a774e98f251aa))
-* fix up some grammer issues ([df47f4d](https://github.com/richwklein/agingdeveloper/commit/df47f4d41c4cbf59db7d6421dc5a25cd9b2cfb5f))
-* tweak wording ([d523cc5](https://github.com/richwklein/agingdeveloper/commit/d523cc55cd31a2140f1fd90c2dbbf930078fcea5))
-* tweak the last few paragraphs ([27ea239](https://github.com/richwklein/agingdeveloper/commit/27ea23904a9b1699f935f2cf37e2412296d4c6aa))
-* fix typo ([7a892be](https://github.com/richwklein/agingdeveloper/commit/7a892be06e9ae61f8260af67b86e808fbd9863e3))
-* fix typo ([d2d44c1](https://github.com/richwklein/agingdeveloper/commit/d2d44c1c95d664bc481655df6cf2123481bd1ce7))
-* Add post aboue default http config ([6e035e8](https://github.com/richwklein/agingdeveloper/commit/6e035e89c4d2db54ddd3616e7d34b8925ff04c40))
-* change how we style disabled links and fix lint issues ([48026f5](https://github.com/richwklein/agingdeveloper/commit/48026f5b20f2dd46ad8ff192406ed4a7061e454f))
-* Article on setting up a custom domain in netlify ([a8f8386](https://github.com/richwklein/agingdeveloper/commit/a8f8386c8fe6c24854f283596bccea30300c8fb8))
-* tweak the breadcrumb styling ([80c2977](https://github.com/richwklein/agingdeveloper/commit/80c2977310455020b2bb60019f88adb20cb9e187))
-* Add the category page and tweak the tag pages ([dc1952b](https://github.com/richwklein/agingdeveloper/commit/dc1952b57e7f2ff4122febf674df70a5523ca04c))
-* Uppercase tags ([9d58ab5](https://github.com/richwklein/agingdeveloper/commit/9d58ab511d1a2cc0ca9193153195a4252605a8cb))
-* Add plugin to ping search providers on publish ([6158f79](https://github.com/richwklein/agingdeveloper/commit/6158f79c5a42fd72827185fe5f7c2d4df4c5ed4f))
-* tweak tag page ([581832f](https://github.com/richwklein/agingdeveloper/commit/581832f203d4396e28d245a259030d6a6462328f))
-* Add the tag pages ([afe144d](https://github.com/richwklein/agingdeveloper/commit/afe144d3f478d70a3ea165a7aa80bab44779a9d0))
-* Trying to get the urls correct ([34d4891](https://github.com/richwklein/agingdeveloper/commit/34d489114e929a267c8d8af6c3f8e47faa2dde1f))
-* fix line length ([498f3c9](https://github.com/richwklein/agingdeveloper/commit/498f3c9e65dc83273434426201a572941aaa3dc4))
-* fix previous/next buttons ([ddb2ce3](https://github.com/richwklein/agingdeveloper/commit/ddb2ce3455ddef90bd3d273775bec5fdab190bb3))
-* fix breadcrumb ([b65ddf8](https://github.com/richwklein/agingdeveloper/commit/b65ddf8a298e2f56311ebd42fcaf602b420bc0d1))
-* fix link in false starts article ([fcb310d](https://github.com/richwklein/agingdeveloper/commit/fcb310d8bee2b5395d14382052c3ebe3f448b1c3))
-* Fix breadcrumb path ([fa26b24](https://github.com/richwklein/agingdeveloper/commit/fa26b241e190812a42a293d068a396780fd3af20))
-* Fix reditect ([29d7980](https://github.com/richwklein/agingdeveloper/commit/29d798077dc3846f3aa3199c43ac109632d592da))
-* Fix output directory ([8ee488a](https://github.com/richwklein/agingdeveloper/commit/8ee488a44ad89e9bad0770914696b3cf5c3d71c4))
-* Add file based build ([cfd3f35](https://github.com/richwklein/agingdeveloper/commit/cfd3f354d11a61d53563d9349d5e0225a5fed7b8))
-* Move the article prefix and switch to file based build ([09a5be9](https://github.com/richwklein/agingdeveloper/commit/09a5be912c0e4c777a9dfc2d911ec6a8a9d9fe7a))
-* Add breadcrumb ([5f7bb48](https://github.com/richwklein/agingdeveloper/commit/5f7bb481718d5d6e8101a55d124d16f0b930f303))
-* Add comments and tweak article layout ([29ce5f3](https://github.com/richwklein/agingdeveloper/commit/29ce5f374ab0cc834b93c08004c88e7bbc9745c0))
-* embed path prefix in article url ([91d2e3e](https://github.com/richwklein/agingdeveloper/commit/91d2e3e23e5c1b24e66cc27935482ec4c327c6f9))
-* Reorder nav bar ([859529a](https://github.com/richwklein/agingdeveloper/commit/859529a3fc1640f88e4aa1b57614739f44aecb63))
-* Add view all button and move articles to article path prefix ([e238260](https://github.com/richwklein/agingdeveloper/commit/e238260338a53651513d3b64d6d590080af2a55c))
-* Fix image sizes on article page on mobile ([d742412](https://github.com/richwklein/agingdeveloper/commit/d742412a143bbd51ae9745f8099f34f63bc09fe6))
-* Land SEO headers ([cf00e88](https://github.com/richwklein/agingdeveloper/commit/cf00e885d9d64ffafd35d80bf17062144897d6af))
-* Issue #27 explain content location ([0579bed](https://github.com/richwklein/agingdeveloper/commit/0579bedfe1de57d9bcd0d6c5e303d24629570d58))
-* Add smoe more lint rules ([5926020](https://github.com/richwklein/agingdeveloper/commit/59260203fd2bad758ce58df5cd981d60b10c4d7c))
-* Adding vscode settings to the workspace ([069c2cb](https://github.com/richwklein/agingdeveloper/commit/069c2cb6e6f483ffd6e4d5a25797fe104142b725))
-* Specifying a ci build ([4293bcb](https://github.com/richwklein/agingdeveloper/commit/4293bcb96c0ec190afa83557392fb597ec9a302f))
-* Specifying a ci build ([43bc710](https://github.com/richwklein/agingdeveloper/commit/43bc7106e53a369b1a78f6a1a0967c67a3d8921d))
-* Update false-start.md ([c0f85db](https://github.com/richwklein/agingdeveloper/commit/c0f85db41c68b32214d9d8a70e49e31ca86ef485))
-* Tweak the avatar display ([dae3745](https://github.com/richwklein/agingdeveloper/commit/dae3745ad0607e22eb6f4533d908fd7cdcd34400))
-* Formatting fixes ([4302530](https://github.com/richwklein/agingdeveloper/commit/4302530b04e510104c25eee6fe1058feedd9fe78))
-* Formatting fixes ([b2bc23f](https://github.com/richwklein/agingdeveloper/commit/b2bc23f4491e136f00a9425c44c5bb9882d38e50))
-* test ([5b8b7a0](https://github.com/richwklein/agingdeveloper/commit/5b8b7a05568810be5d90e33e57cbef26bf6d0561))
-* Formatting fixes ([1e6bd4e](https://github.com/richwklein/agingdeveloper/commit/1e6bd4e724046f7dc75f4054065dd679fa8bbc96))
-* Fix eslint formatting ([82e89e6](https://github.com/richwklein/agingdeveloper/commit/82e89e64ef029e8f66ade6ff49d34ac0d81e5da3))
-* Fix formatting based on eslint ([83c5011](https://github.com/richwklein/agingdeveloper/commit/83c501145b3726fb381daa4f91d732a71f10fca9))
-* switch to using eslint instead of prettier and use the google styles ([1931048](https://github.com/richwklein/agingdeveloper/commit/1931048836ecd63cd665ef991d3f23eb009c3918))
-* Switch from prettier to eslint and use google's rules ([271e003](https://github.com/richwklein/agingdeveloper/commit/271e0031a4053ecad30bc246c752790cfdb69f79))
-* fix index title ([6e7a808](https://github.com/richwklein/agingdeveloper/commit/6e7a808d2e95ab60374f3c1373225df9fec88392))
-* Second article with fixes for image sizes and titles ([2bfb01c](https://github.com/richwklein/agingdeveloper/commit/2bfb01cdd5ce3ff0b00f57dba30f0a0884a91236))
-* Make components as standalone as possible and update the theme ([9a908cc](https://github.com/richwklein/agingdeveloper/commit/9a908cc20df2b3d2416516378cf9cd2b68cf4e20))
-* blah ([bf1c0f8](https://github.com/richwklein/agingdeveloper/commit/bf1c0f88473b26f8215dc68b9e7a1575d3084416))
-* More work on the author page ([1190ae5](https://github.com/richwklein/agingdeveloper/commit/1190ae50453bd047473af75c9e1ac708419c1acf))
-* Moving scroll logic into layout ([1ecc892](https://github.com/richwklein/agingdeveloper/commit/1ecc892dbf50e218126afccffd7b47ef9126eb61))
-* Moving scroll logic within layout ([332b0f8](https://github.com/richwklein/agingdeveloper/commit/332b0f8a686bfcd40fd99a721514dbce3c413688))
-* Moving scroll logic into layout ([f72e8e5](https://github.com/richwklein/agingdeveloper/commit/f72e8e560bce8604643bf7cb348ae76643b20ef1))
-* Moving scroll logic into layout component ([9c6d6ce](https://github.com/richwklein/agingdeveloper/commit/9c6d6ce16fe97deda23982eaf3d62f2443d65d66))
-* Move scroll logic into layout ([5105737](https://github.com/richwklein/agingdeveloper/commit/510573784cb400cb9c192fb6e4c29f011a0612a6))
-* Move scrolling into layout and fix ([5524430](https://github.com/richwklein/agingdeveloper/commit/5524430adf7d3009b835752eafa57a9aeba8211e))
-* Fix scrolling to top ([7193b80](https://github.com/richwklein/agingdeveloper/commit/7193b80a12e0dfda675d89a0b333fc12a19faeeb))
-* Start getting author setup ([95a9b5b](https://github.com/richwklein/agingdeveloper/commit/95a9b5bdcbb36bc196680d306cd38a951a8491b5))
-* add link to image ([ac22e73](https://github.com/richwklein/agingdeveloper/commit/ac22e73a0e3df0edf607742ef1392d1d0c5f23a6))
-* Change date format on article card ([5259af6](https://github.com/richwklein/agingdeveloper/commit/5259af6a07425af61d83cd48752c89c1688cb909))
-* Darken the text in the banner ([a7da6bf](https://github.com/richwklein/agingdeveloper/commit/a7da6bfbe0de08b7e02c3e10c0f5de24ef7fa86e))
-* Change the grey color ([8dae2ce](https://github.com/richwklein/agingdeveloper/commit/8dae2ce25f518b23407f84c15b5261b0f087e6f8))
-* Change grid spacing on banner ([f623bdd](https://github.com/richwklein/agingdeveloper/commit/f623bddf56962be9b1039b418dcb484cc4ca6fd8))
-* Get rough draft of home done ([cbeeba1](https://github.com/richwklein/agingdeveloper/commit/cbeeba197f4dcd690f51429756bae94625f7b244))
-* Update intro.md ([11ee501](https://github.com/richwklein/agingdeveloper/commit/11ee501ce7f814dfcb97018239f524db6e1a9c4c))
-* Update intro.md ([2627012](https://github.com/richwklein/agingdeveloper/commit/26270128666d37170445e37ea9e84989b6edb44d))
-* Add a colon to the warning ([781b8ab](https://github.com/richwklein/agingdeveloper/commit/781b8ab3bbe40acc50c3a42087f07b7a1cc3025b))
-* Update gatsby-node.js ([edb34cc](https://github.com/richwklein/agingdeveloper/commit/edb34cc132a2922493c5427da30cec5d5aa684fd))
-* update the intro post ([6a53bb7](https://github.com/richwklein/agingdeveloper/commit/6a53bb75dab58b308ec902ad258cb25967ba9813))
-* change the file name and url ([c604698](https://github.com/richwklein/agingdeveloper/commit/c6046981ad40a5cb4368762d88b880f9ce165804))
-* Get the first post in the books ([6c4c83a](https://github.com/richwklein/agingdeveloper/commit/6c4c83a2c35fe6950514b09bb035c9b62dc1567b))
-* Get article pages working ([2b363a6](https://github.com/richwklein/agingdeveloper/commit/2b363a67b9ea55401271e981bc74c1207178ec38))
-* Get the footer working ([1d45d9e](https://github.com/richwklein/agingdeveloper/commit/1d45d9e1bdc3da48dc4064294beb3a799ba00da9))
-* Add site navigation ([a0922ba](https://github.com/richwklein/agingdeveloper/commit/a0922ba8f48799a2849950ae9660e81d45100e2f))
-* Add keybase signature to show site ownership ([aedcdba](https://github.com/richwklein/agingdeveloper/commit/aedcdba8db8a5ddc50b50a9f5de47c156832276a))
-* Use a close button for the nav drawer ([c40400f](https://github.com/richwklein/agingdeveloper/commit/c40400f0333809c853646d7312d806a51d289975))
-* wip ([75b9d12](https://github.com/richwklein/agingdeveloper/commit/75b9d12f2494e5d36bb2cd2fdcd730340e0aa267))
-* set the typography and prefetch google fonts ([08bb726](https://github.com/richwklein/agingdeveloper/commit/08bb726b2344a995d96ad909c4cf4a254e4aa40c))
-* fix fousc ([5add831](https://github.com/richwklein/agingdeveloper/commit/5add8310f04176a73b16714abaff84e587bb9127))
-* tweak readme license info ([dfe545a](https://github.com/richwklein/agingdeveloper/commit/dfe545ab2805e6bf7170fe4b65631d3d830b4d08))
-* tweak readme ([404d26f](https://github.com/richwklein/agingdeveloper/commit/404d26f43f274292e9171e51e6ebaad2c19b5214))
-* Start landing where I'm at ([592c296](https://github.com/richwklein/agingdeveloper/commit/592c296a9cec21c8401507d418ff517de955aeb6))
-* Get the footer back in ([a01c7f1](https://github.com/richwklein/agingdeveloper/commit/a01c7f1608d6fe6545143bfe3e107575d0de1ec6))
-* cleanup ([e638024](https://github.com/richwklein/agingdeveloper/commit/e638024fea9d90e9a75e9f6a688c6542eb77875e))
-* ignore the package-lock file ([bb3af09](https://github.com/richwklein/agingdeveloper/commit/bb3af0985bb2a5e230596dd7a9299026b81ea1a6))
-* do not commit package-lock ([778897a](https://github.com/richwklein/agingdeveloper/commit/778897a7d7d421e849dcf33e6210df344164c0b1))
-* Trying to get a working build ([fbf0e7e](https://github.com/richwklein/agingdeveloper/commit/fbf0e7e001c5f16d71abbd1bb1ca3dedee155888))
-* still building ([14657c4](https://github.com/richwklein/agingdeveloper/commit/14657c4ac49a98c544e0832dcf5143749ed3e5f8))
-* find the footer ([07d0ac8](https://github.com/richwklein/agingdeveloper/commit/07d0ac8adac2f458c641bb0c1bdbf37fae53e62c))
-* Building ([12932d1](https://github.com/richwklein/agingdeveloper/commit/12932d1a25d910f3ed6b88c73bc37db799bb49e4))
-* Get netlify build working again ([e914aaf](https://github.com/richwklein/agingdeveloper/commit/e914aaf943cb90e23607c802b72c7a2377b8b0d3))
-* Trying to get builds working ([f633dd8](https://github.com/richwklein/agingdeveloper/commit/f633dd8ddc18d52db486034ca2560dbd033e48ff))
-* landing material design change ([2ac73a7](https://github.com/richwklein/agingdeveloper/commit/2ac73a711033f3a8fd5089d8c45917948c231dcf))
-* fix ssr ([434577f](https://github.com/richwklein/agingdeveloper/commit/434577fed2be7d1fd1d566bcbe5e8e2ccef8c91d))
-* Get theme colors set ([0becb1e](https://github.com/richwklein/agingdeveloper/commit/0becb1e77fde0a349deb8efee5210eebb55bb5b5))
-* commit the package-lock.json ([1bfe74b](https://github.com/richwklein/agingdeveloper/commit/1bfe74b4953053ae115874e468b669512115069b))
-* setup browser and ssr ([6ae685f](https://github.com/richwklein/agingdeveloper/commit/6ae685f3dedf445c5b681a0cf38d1635e793b05d))
-* Update the readme and remove the old mocks ([e677c2b](https://github.com/richwklein/agingdeveloper/commit/e677c2b4a5f16a492c59610ced1389dd7d9ce262))
-* Basic layout in place ([82a1343](https://github.com/richwklein/agingdeveloper/commit/82a1343151b6823d7f9236e49c8c3053ba9221a3))
-* Layout fixes ([d3fdd97](https://github.com/richwklein/agingdeveloper/commit/d3fdd972c5dc97881f4e616569968e2ab0fce713))
-* fix up make file ([a59f796](https://github.com/richwklein/agingdeveloper/commit/a59f7968a8e18f7d76885767835de6776f02b4fb))
-* netlify is still throwing errors ([116730a](https://github.com/richwklein/agingdeveloper/commit/116730aebb3577f046bf0626bd8be6c423ff27d0))
-* still trying to get it working ([264a59e](https://github.com/richwklein/agingdeveloper/commit/264a59e41cbea1556cacca322ec9b47ec2c34018))
-* Fix up the make files ([8ed9463](https://github.com/richwklein/agingdeveloper/commit/8ed9463c05bafc7416b60a85fb621fc802745aa5))
-* enable incremental builds ([c3d70d9](https://github.com/richwklein/agingdeveloper/commit/c3d70d9383592f333b7afba75f4513ec338eecc8))
-* Bump prettier from 2.0.4 to 2.0.5 ([4d54195](https://github.com/richwklein/agingdeveloper/commit/4d54195ce9e2cc42a789109e0f2b0247e68ad0fe))
-* Bump prettier from 2.0.3 to 2.0.4 ([14693b6](https://github.com/richwklein/agingdeveloper/commit/14693b606ac9ccd5f7258da8bc951553135def1a))
-* Bump prettier from 2.0.2 to 2.0.3 ([ee0c52a](https://github.com/richwklein/agingdeveloper/commit/ee0c52afe12bafe005a39b2115985b9900ece49d))
-* Bump prettier from 2.0.1 to 2.0.2 ([f922046](https://github.com/richwklein/agingdeveloper/commit/f9220463a1a0d7567d625c053eb3bc2f050bce02))
-* Bump prettier from 1.19.1 to 2.0.1 ([c52f0cd](https://github.com/richwklein/agingdeveloper/commit/c52f0cdb5b48483f09ca766605a94b9941c1cac8))
-* Add a markdown file to fix build ([fc900ed](https://github.com/richwklein/agingdeveloper/commit/fc900edd6d9deec721352f631600897621e489e1))
-* Updated layout ([12b020a](https://github.com/richwklein/agingdeveloper/commit/12b020a15a80d59a2109b39ea9f19ed3372b8922))
-* Update the styling to improve it. ([a04dcd8](https://github.com/richwklein/agingdeveloper/commit/a04dcd81a62841e53304c15648568e2b4793a46f))
-* Add a 404 page ([884c3cc](https://github.com/richwklein/agingdeveloper/commit/884c3ccb23e135d07ae4356e7f453362001a9d46))
-* Remove adsense ([55ab42d](https://github.com/richwklein/agingdeveloper/commit/55ab42d0494aae87a07ed0e66f9e060195f40271))
-* Set up analytics and ads ([35fcc90](https://github.com/richwklein/agingdeveloper/commit/35fcc90a68f3563d24670e4d122aa65a7fc5adfa))
-* fix robots.txt ([7634dae](https://github.com/richwklein/agingdeveloper/commit/7634daecb92eb908ed507fae6879910737f4064b))
-* fix robots.txt ([5a5f3b0](https://github.com/richwklein/agingdeveloper/commit/5a5f3b0a5a8e0fbd81decb9874ab7cfa0f589f5f))
-* fix robots.txt ([175365c](https://github.com/richwklein/agingdeveloper/commit/175365cc13a62b0439aa009706c014926305d2a9))
-* Add site navigation ([79a2053](https://github.com/richwklein/agingdeveloper/commit/79a2053da029009e05f29fc51de7e70618562b2b))
-* Fix makefile and simplfy gatsby-config ([ce2e9c2](https://github.com/richwklein/agingdeveloper/commit/ce2e9c26d26343bba4a8373cfcd6e466a4913abc))
-* Fix makefile and simplfy gatsby-config ([cbdb7ad](https://github.com/richwklein/agingdeveloper/commit/cbdb7ad7fcebed6b32d0b7e3ed3ac12454ffef19))
-* Set up canonical urls ([5a9e323](https://github.com/richwklein/agingdeveloper/commit/5a9e323db2fe50e6b839106203d8a42ebb778f38))
-* Set up makefile and move todos to github issues ([49595b9](https://github.com/richwklein/agingdeveloper/commit/49595b97edaadb30cbe9b7d75985f2b2fb194a33))
-* Move the table of contents ([c426c39](https://github.com/richwklein/agingdeveloper/commit/c426c395bf56949dcec70c468d454c7b333e4009))
-* Move the table of contents ([5283668](https://github.com/richwklein/agingdeveloper/commit/52836684ed8a87e682d923071059adaf055cb98d))
-* Move the table of contents ([9ddea92](https://github.com/richwklein/agingdeveloper/commit/9ddea9206ac8aaa95889ad2561fcf05af7a07ba8))
-* Move the table of contents ([730bfc6](https://github.com/richwklein/agingdeveloper/commit/730bfc6b9a244bcd5a3aee160518c2263b30d18d))
-* Move the table of contents ([b6e779b](https://github.com/richwklein/agingdeveloper/commit/b6e779b9e4847448c0cc801f52445ee73e7b76ee))
-* change path to mocks ([622203e](https://github.com/richwklein/agingdeveloper/commit/622203e86a3ef376c32792b77e5ad686f0d7b2a8))
-* fix path to license ([32d097a](https://github.com/richwklein/agingdeveloper/commit/32d097aad620109d20165d5b13cb373e1884c530))
-* Define Licensing ([f8ff285](https://github.com/richwklein/agingdeveloper/commit/f8ff285b6c8080742f3cfb55a5f892e6f4eb7ce1))
-* Add sitemap and robots files ([1425b1d](https://github.com/richwklein/agingdeveloper/commit/1425b1db300420171d20dd8389f76beeac295dc8))
-* Add sitemap and robots files ([cb85297](https://github.com/richwklein/agingdeveloper/commit/cb8529784e4ed578b2d5af34db4ce8b55f3bdc46))
-* Initial Titlebar implementation ([b0c825a](https://github.com/richwklein/agingdeveloper/commit/b0c825a94357788397d62318561bf094098826e5))
-* Update gitignore to include package-lock ([4a712bd](https://github.com/richwklein/agingdeveloper/commit/4a712bd0bc759385ae6b35b6e68e91ea769e0eb7))
-* Remove package-lock.json from repo ([47c6a40](https://github.com/richwklein/agingdeveloper/commit/47c6a405ae72148c27ce677e6b7bbcd8ca849217))
-* Set up code owners ([64d2b2e](https://github.com/richwklein/agingdeveloper/commit/64d2b2ef7157e930729852dcaa100960f3fec288))
-* Prettify code and fix lint issues ([cae99a4](https://github.com/richwklein/agingdeveloper/commit/cae99a458daefb2b5bbc0ebb9a829e39892eb056))
-* Prettify code and fix lint issues ([a3939b4](https://github.com/richwklein/agingdeveloper/commit/a3939b45d198e3bf72fcf1ad4aa9b109e23d7e5f))
-* Prettify code and fix lint issues ([4cf70f5](https://github.com/richwklein/agingdeveloper/commit/4cf70f5b9ebd832e024799a0d5cf45f5e8a907c8))
-* Prettify code and fix lint issues ([89f7b14](https://github.com/richwklein/agingdeveloper/commit/89f7b1414cfdc52f385ba8fe4914ddf1c831d007))
-* Make the move to an empty gatsby project ([f5543bb](https://github.com/richwklein/agingdeveloper/commit/f5543bb43afcce53a681aa07dd9bda6c1fd5360e))
-* Tweaking the readme ([b03a4aa](https://github.com/richwklein/agingdeveloper/commit/b03a4aa2df2205d2647da2ca58fe23d1d1a1c7ee))
-* Tweaking the readyme ([eba1445](https://github.com/richwklein/agingdeveloper/commit/eba14454e65ca2a5549306f80ec80139391565e7))
-* Tweaking the readme file ([25e0c0c](https://github.com/richwklein/agingdeveloper/commit/25e0c0c03fd0df1884d64ee93c5f6e612078cd39))
-* Update README.md ([a7f10aa](https://github.com/richwklein/agingdeveloper/commit/a7f10aa0faa412f1593081e0508e956461769e7f))
-* Update README.md ([b880597](https://github.com/richwklein/agingdeveloper/commit/b8805978fbae38e8ad2c561133ad35fb6f320c33))
-* Update README.md ([8483d6b](https://github.com/richwklein/agingdeveloper/commit/8483d6b815ea55102c8fdab7d60dfb9be98302c6))
-* Update the readme ([017ebb9](https://github.com/richwklein/agingdeveloper/commit/017ebb9ade668b4fd8eb045fc8bd4e68a7e9d4f5))
-* More cleanup ([a41580d](https://github.com/richwklein/agingdeveloper/commit/a41580d40c7c97dafd3e383f51b7a7e83b5af123))
-* Remove dead content ([90ce3bb](https://github.com/richwklein/agingdeveloper/commit/90ce3bb7f12da9428e561d8263da311b94a0cc49))
-* Updates to gitignore and jshint ([1f12a99](https://github.com/richwklein/agingdeveloper/commit/1f12a99af178cadb9c743d8e57617f732a4cf8df))
-* Site metadata ([6c4aec2](https://github.com/richwklein/agingdeveloper/commit/6c4aec25b95b4386d71e2b2e7717dbb714068c11))
-* Cleaning up gitignore ([569ea39](https://github.com/richwklein/agingdeveloper/commit/569ea398d86a9b2c95b0207d5e5e3dd4474907e7))
-* Initial commit from gatsby: (git@github.com:gatsbyjs/gatsby-starter-blog.git) ([aa43efc](https://github.com/richwklein/agingdeveloper/commit/aa43efc279b570c4469b9634468350df79efe72e))
+- Bump the github-actions group with 1 update ([7964953](https://github.com/richwklein/agingdeveloper/commit/79649535dd509ba683aa5d5ae072d05d36c3bc92))
+- Tag on package version change ([c74d94f](https://github.com/richwklein/agingdeveloper/commit/c74d94f9a8cd370fe493aa4cb8c72048c61e0bf2))
+- try setting the token via env ([080832a](https://github.com/richwklein/agingdeveloper/commit/080832a95a191fa13345fa5ac0e9b4d1fcec45d5))
+- fix workflow ([ffa5332](https://github.com/richwklein/agingdeveloper/commit/ffa53324408d4baff9ed84d0520adf40fb8ad5d7))
+- Fix linting and run docs ([8ee86f3](https://github.com/richwklein/agingdeveloper/commit/8ee86f3cf62597ad46640efcd8f8916432e116c0))
+- still trying to get coverage to work ([750e92d](https://github.com/richwklein/agingdeveloper/commit/750e92dcc03ec64fad94d6e503e68a01190ddd0b))
+- [skip ci] Update the github actions to try and make them work ([b2c2269](https://github.com/richwklein/agingdeveloper/commit/b2c22691528373ad51dab959ec00b4df1d78c6b6))
+- Add offline support and tweak code coverage action ([65f3086](https://github.com/richwklein/agingdeveloper/commit/65f3086565bc7926f877f1fa32f9fdda7ac65034))
+- Include a code coverage action ([0cf33d1](https://github.com/richwklein/agingdeveloper/commit/0cf33d10083499d4b81a049c035a9bcf45bc3818))
+- Add a github action to bump the package version and tag a release ([b99bd12](https://github.com/richwklein/agingdeveloper/commit/b99bd126189877920c2f4809773b35470b8b5156))
+- Update the repo config ([f04c570](https://github.com/richwklein/agingdeveloper/commit/f04c570b3a6f58a4d234303cf85884ffe80f0e0c))
+- Remove netlify.toml ([4e075d8](https://github.com/richwklein/agingdeveloper/commit/4e075d89493ff1414690290869efc00bd298f5e9))
+- remove package lock and fix description ([11150c6](https://github.com/richwklein/agingdeveloper/commit/11150c63364aff27871af36cb667626e32926bfe))
+- tweak the code blocks for better support ([9f8b74e](https://github.com/richwklein/agingdeveloper/commit/9f8b74e39d0fcfc5d57f6463728185b077f8051a))
+- Add another test to make sure the component handles a string child ([19a34a8](https://github.com/richwklein/agingdeveloper/commit/19a34a8e1f0229b4d565ea4836d0c00a49e5cf43))
+- Replace the rendering of code blocks with the prism-react-renderer component ([8c4e53e](https://github.com/richwklein/agingdeveloper/commit/8c4e53e639b14d33662e38e6675476a8732fee92))
+- fix snapshots ([b2eb6bb](https://github.com/richwklein/agingdeveloper/commit/b2eb6bb3d7e52a2b06e646d9c78de8b1b4a189ef))
+- upgrade icon dependency and remove lock file ([2cf8ed6](https://github.com/richwklein/agingdeveloper/commit/2cf8ed6c1a5d457f0ceca3d20a53580621693fad))
+- Bump the npm_and_yarn group across 1 directories with 2 updates ([db1c20d](https://github.com/richwklein/agingdeveloper/commit/db1c20d31e94652133805f5f00520b798aeac879))
+- Bump @mui/material from 5.15.3 to 5.15.4 ([8b21e0d](https://github.com/richwklein/agingdeveloper/commit/8b21e0d082deb95d820d280a57428f74a4797b1f))
+- fix casing ([c28e19c](https://github.com/richwklein/agingdeveloper/commit/c28e19ca245ad6f2702009e28b5928ffcba6db9d))
+- Drop the slug property from the site json ([194be3e](https://github.com/richwklein/agingdeveloper/commit/194be3eaad7d195d8ce621c51c0c612c3d496eba))
+- fix bad formatting by eslint ([a7f2667](https://github.com/richwklein/agingdeveloper/commit/a7f2667f93e7ddd8bf8615757f006969f5fc1a68))
+- Switch from using yaml to json for data ([32ef727](https://github.com/richwklein/agingdeveloper/commit/32ef7274d1275e6a7e392ed996f8ca998350b570))
+- remove unused import ([e499afc](https://github.com/richwklein/agingdeveloper/commit/e499afc16cdfb091a5f074ab7ca38a9d0696f85c))
+- Move redirects to a separate file ([7e8152f](https://github.com/richwklein/agingdeveloper/commit/7e8152fc99e8450569ebb7c97cd737e8a3cdad76))
+- Enforce the fields in the article frontmatter and use custom resolvers for defaults ([e7dccfa](https://github.com/richwklein/agingdeveloper/commit/e7dccfab51dd867a0c6e5706a7d5c2727f33c513))
+- Fix misplaced image ([41a739d](https://github.com/richwklein/agingdeveloper/commit/41a739d5e000c64bb39b24ad475e8091cc752e42))
+- Bump @mui/material from 5.15.2 to 5.15.3 ([7b25451](https://github.com/richwklein/agingdeveloper/commit/7b254513d7ccced8ce484a881b394ab6d93e260c))
+- Bump @mui/icons-material from 5.15.2 to 5.15.3 ([1175407](https://github.com/richwklein/agingdeveloper/commit/11754079d9976650bc139fa58906f5a5a4119852))
+- Bump @testing-library/jest-dom from 6.1.6 to 6.2.0 ([0213959](https://github.com/richwklein/agingdeveloper/commit/021395927742b3a7e6e7612f30074f20a82c4753))
+- Move keybase file so it is served ([51648c3](https://github.com/richwklein/agingdeveloper/commit/51648c3b62dde7c999433927b45e473c0b465ba4))
+- get analytics working??? ([972be2e](https://github.com/richwklein/agingdeveloper/commit/972be2ea0abfa0e4431c9d1239661cd374860ad6))
+- Bump @mui/material from 5.14.18 to 5.15.2 ([a9acd82](https://github.com/richwklein/agingdeveloper/commit/a9acd8229d6a53047f59d8dbff1f2e8c60c1316b))
+- Bump @emotion/react from 11.11.1 to 11.11.3 ([138c825](https://github.com/richwklein/agingdeveloper/commit/138c825ad8ab1f022f1e80a77fcb88550cb31219))
+- Fix issue with twitter cards ([67eb738](https://github.com/richwklein/agingdeveloper/commit/67eb738173c57c2b04e229b501afeb164e32e9b8))
+- Bump @testing-library/jest-dom from 6.1.4 to 6.1.6 ([d5ce224](https://github.com/richwklein/agingdeveloper/commit/d5ce224e7ba6469cf631efbd8a639cf82a8de000))
+- Bump @mui/icons-material from 5.14.18 to 5.15.2 ([bb40ea4](https://github.com/richwklein/agingdeveloper/commit/bb40ea41526397ee2cd37c1ad535d337217b26d5))
+- tweaks for the newest article ([20a667d](https://github.com/richwklein/agingdeveloper/commit/20a667de99bc0cea707bd3e851f85e0658db9c54))
+- fix syntax highlighting ([e389d02](https://github.com/richwklein/agingdeveloper/commit/e389d0208226f240c3a62061749afdfccc9f10c7))
+- pluralize ([a229811](https://github.com/richwklein/agingdeveloper/commit/a229811b746da36ac09b89d89b8c40b07e16e368))
+- Rebuild article ([045119b](https://github.com/richwklein/agingdeveloper/commit/045119b15a30af8d22ec56ad379351411eac75d5))
+- Add back in sitemap support ([ef4bf61](https://github.com/richwklein/agingdeveloper/commit/ef4bf619dfccfec33703e0c41409bbb5d9be14b2))
+- Add docs ([20c47c3](https://github.com/richwklein/agingdeveloper/commit/20c47c3a0ccbdffd85d7fde8d7c2991de7cd6e5c))
+- Add manifest and favicon ([f3b4f88](https://github.com/richwklein/agingdeveloper/commit/f3b4f8868a092bd18e8be5e01aa8e43da931934a))
+- Add author index page ([12a903a](https://github.com/richwklein/agingdeveloper/commit/12a903afc633e51bd662c78a2ea2af8adb007269))
+- Fix redirect rule ([2eb20d6](https://github.com/richwklein/agingdeveloper/commit/2eb20d620abd32fd7dff0c792a2346ada389704f))
+- fix up the redirects ([8cf801d](https://github.com/richwklein/agingdeveloper/commit/8cf801d266160dbefd12c521e1110a05bd75eec5))
+- Set up build file and redirects ([a64938d](https://github.com/richwklein/agingdeveloper/commit/a64938d5a9746f3856e5d2b66a3a314b3ec7d6d8))
+- Add a template for rendering author pages ([4080327](https://github.com/richwklein/agingdeveloper/commit/40803279cb58acf53ae3bbf75a92fe387772543f))
+- Add a button to navigate back ([10d82d1](https://github.com/richwklein/agingdeveloper/commit/10d82d1dff333ce7d466757058b533088ccd04f9))
+- Add google analytics ([b85fe58](https://github.com/richwklein/agingdeveloper/commit/b85fe58a7e4f1bcf06a3acb814bc4e1780cbc999))
+- Add robots.txt ([15b899f](https://github.com/richwklein/agingdeveloper/commit/15b899f7a01319ec294fecb70426a70d8573d6e5))
+- Fix unit tests ([4946347](https://github.com/richwklein/agingdeveloper/commit/4946347f2f4d0045007c794944d8ae28287e7cdd))
+- Fix unused imports ([e28650b](https://github.com/richwklein/agingdeveloper/commit/e28650b645989a2cfea5dfaf9d76d6df21a26068))
+- Bump gatsby version and tweaks ([7b1dc45](https://github.com/richwklein/agingdeveloper/commit/7b1dc45a5c61aca6aecc59e5c2740e47e162d5aa))
+- Add SocialButtonBar tests ([5bf8082](https://github.com/richwklein/agingdeveloper/commit/5bf80827880c1bfc6bde682091199f7d918bff0e))
+- Add todo for tests ([66bc467](https://github.com/richwklein/agingdeveloper/commit/66bc4671b7fe6614cd1126228a835805a15fae8b))
+- fix console errors and sort exports ([df833b9](https://github.com/richwklein/agingdeveloper/commit/df833b92e7ded7bdeeac4cddff984cca3383a1b4))
+- Get archive pages working ([1004ad3](https://github.com/richwklein/agingdeveloper/commit/1004ad3fc7e27c4304267d3525669b8476ba1d98))
+- Bump dependencies ([04d76b2](https://github.com/richwklein/agingdeveloper/commit/04d76b2bb5264ddffd54968db43d37649282f0f7))
+- Get build fixed ([87e1213](https://github.com/richwklein/agingdeveloper/commit/87e12130a6db9ec0b1c0f21d43627ce602a81e5c))
+- change frontmatter field to be "published" instead of "date". Continue adding SEO. ([39255a2](https://github.com/richwklein/agingdeveloper/commit/39255a20e469e53b17a685da196739a006616780))
+- Get documentation in a good spot and all current pages rendering. ([0db8045](https://github.com/richwklein/agingdeveloper/commit/0db8045f617e2bc909630c76d9e3296ee90cd175))
+- more docstrings ([75a46d8](https://github.com/richwklein/agingdeveloper/commit/75a46d8715608614b024d6fcf0945ade92174435))
+- Adding more docstrings and getting the tag breadcrumb to work ([e525fd6](https://github.com/richwklein/agingdeveloper/commit/e525fd6c384ac43e07d3495d60fb3ac0a2b8da7f))
+- Add title block docs ([b2866a4](https://github.com/richwklein/agingdeveloper/commit/b2866a4c7b32270444cf1e2caf3f55ee96b1936f))
+- Add docs and tests to DisplayLimit ([3bd09a6](https://github.com/richwklein/agingdeveloper/commit/3bd09a655fd6898ed367387692594929dfe39668))
+- working on tests ([85414d6](https://github.com/richwklein/agingdeveloper/commit/85414d65e560a8195367bd9e1f57ac12a0eb7000))
+- Additional docs ([ddc6e1a](https://github.com/richwklein/agingdeveloper/commit/ddc6e1a36876f85bccfe1ed73b1bce2b27d4f41c))
+- test fixes ([a243454](https://github.com/richwklein/agingdeveloper/commit/a2434541c007aa5a23da4a2d506d20d78c11e870))
+- Start adding jsdocs and improving code ([4df88f0](https://github.com/richwklein/agingdeveloper/commit/4df88f078ac5fd29d7173dddff680a109b83d29e))
+- Get queries working for all the pages ([d9d479a](https://github.com/richwklein/agingdeveloper/commit/d9d479a681842fe55a954c9d9e28d4a7841ff8e7))
+- fix build ([6e6537b](https://github.com/richwklein/agingdeveloper/commit/6e6537bde1ac857d381ff41401033b2cc90d59e4))
+- fix build ([0bb9a82](https://github.com/richwklein/agingdeveloper/commit/0bb9a82d5ea3afe4224aca368ffa3bd88a10a438))
+- Get full height body working ([680f90d](https://github.com/richwklein/agingdeveloper/commit/680f90dc2c9b1ac8628aa7e474656fad464e7ab5))
+- Move around components ([9446777](https://github.com/richwklein/agingdeveloper/commit/9446777d24acf5f73fd744b75ab05fa5accadfa6))
+- Add fonts ([c307643](https://github.com/richwklein/agingdeveloper/commit/c3076435a93c0ebe5dd2d9422d4ff88201717ed8))
+- Increase the number of articles on the front page ([3882661](https://github.com/richwklein/agingdeveloper/commit/3882661710d8c9c90c6f6cdec6e9787ebfe39f7a))
+- add formatting back to ci build ([ee1f759](https://github.com/richwklein/agingdeveloper/commit/ee1f75945a7c6bee3b8a1c4820e601acf10b90c5))
+- tweak some styles ([f5a38b9](https://github.com/richwklein/agingdeveloper/commit/f5a38b9750002ec28d17ce5dbf38752e1026df94))
+- Reduce the blur on the hero image ([b089757](https://github.com/richwklein/agingdeveloper/commit/b089757894e762587e411edf6baa61fbc2ff4bf4))
+- Add the rest of the content to the branch ([b52b34b](https://github.com/richwklein/agingdeveloper/commit/b52b34bb6df04eec65fa1c8663f94654a79f9873))
+- fix author slug ([d734bd0](https://github.com/richwklein/agingdeveloper/commit/d734bd01af15b0af57abacd958c1c7b659437552))
+- Add TODOs ([b9769b7](https://github.com/richwklein/agingdeveloper/commit/b9769b79ebe60e744cfc50b6fc33bb2810646eec))
+- Get a hero block added to the home page ([e3e124d](https://github.com/richwklein/agingdeveloper/commit/e3e124dc49f07821f34072549cb4505832a434be))
+- Add time to read to the article template ([ccbc9e7](https://github.com/richwklein/agingdeveloper/commit/ccbc9e726071919e8455c3eb9eae5048b059afa3))
+- Get the avatar on the top bar ([7430995](https://github.com/richwklein/agingdeveloper/commit/74309955a4898cfbd50271cb2ed4305b8819fce1))
+- Improve TagBar and tests ([8083099](https://github.com/richwklein/agingdeveloper/commit/8083099ace617807face7b7025264a709d533bc3))
+- Try and get the ci working ([f2733c1](https://github.com/richwklein/agingdeveloper/commit/f2733c1a6e1b1e29db9b02f96fd7c058332a14ef))
+- Add another page ([aebed87](https://github.com/richwklein/agingdeveloper/commit/aebed8721b758abfab0659315d224be545d08930))
+- Add tagbar support ([2cd0e79](https://github.com/richwklein/agingdeveloper/commit/2cd0e796efa0c96cecff283eb56d37c4217f3904))
+- Add featured image support ([b537bc9](https://github.com/richwklein/agingdeveloper/commit/b537bc96ed0fe9d76e0e5f7d3f5253de99679dc2))
+- Move the title block to a component ([d06f47b](https://github.com/richwklein/agingdeveloper/commit/d06f47beece7abeff313f7cae6d9c050e69eecf1))
+- Article By Line ([d308c4a](https://github.com/richwklein/agingdeveloper/commit/d308c4a8e67b364d12d2c60833e8ce7253634d56))
+- more progress ([ae616a3](https://github.com/richwklein/agingdeveloper/commit/ae616a3e06be528f330d2b8479e2364fc8e2799d))
+- Adding tests ([59a3b86](https://github.com/richwklein/agingdeveloper/commit/59a3b8604f42395cf5014815aa5e8839fea63d04))
+- Switch basic testing to be snapshots ([c9cb1d4](https://github.com/richwklein/agingdeveloper/commit/c9cb1d41a8c58a1262c97e2be0a88400f6cf8401))
+- Start unit testing ([c94498a](https://github.com/richwklein/agingdeveloper/commit/c94498a765d0ce1bf23ecfe562a4610382bad35d))
+- initial work ([d122750](https://github.com/richwklein/agingdeveloper/commit/d122750869a75a4f430f32874ff62ddd8a7de9cc))
+- initial work ([a91123e](https://github.com/richwklein/agingdeveloper/commit/a91123e1bcecf8cd0852a9f624d6fb77cf24b5e1))
+- Starting over ([1d8e81d](https://github.com/richwklein/agingdeveloper/commit/1d8e81d2912bbd94c830851cdb977074194a6911))
+- Attempt to update node version used in build ([884771d](https://github.com/richwklein/agingdeveloper/commit/884771d342bd9b9dee18d25983081de696986451))
+- Bump eslint from 7.32.0 to 8.36.0 ([c2d6c27](https://github.com/richwklein/agingdeveloper/commit/c2d6c27db1b2d293803badc8abb6fa5f66ae13bc))
+- ignore cache directory and increase dependabot ([f876237](https://github.com/richwklein/agingdeveloper/commit/f876237828f73106af51477060319163a66ef7e4))
+- Bump gatsby-remark-images from 3.11.1 to 7.7.0 ([7116103](https://github.com/richwklein/agingdeveloper/commit/71161031ffe0a7dc24c1a2e56555432f9bb84e57))
+- Bump eslint from 7.32.0 to 8.36.0 ([d9f8b3f](https://github.com/richwklein/agingdeveloper/commit/d9f8b3f8641bbd8f48315bda06de92a18ceb73ee))
+- Bump gatsby-remark-prismjs from 3.13.0 to 7.7.0 ([bb1801b](https://github.com/richwklein/agingdeveloper/commit/bb1801b51414652382a3e9c42bdc7ef25a4d34bd))
+- Bump eslint-config-react-app from 6.0.0 to 7.0.1 ([f808db9](https://github.com/richwklein/agingdeveloper/commit/f808db93c9d04b317fb6fd36075a4dfdd9440edf))
+- Fix security mdx vulnerability ([1c63827](https://github.com/richwklein/agingdeveloper/commit/1c63827439f28fad63e4185377070a9620bab691))
+- Update index.md ([302193b](https://github.com/richwklein/agingdeveloper/commit/302193b95e5d9d7166a1358da86f457a62e7db4c))
+- Finish the article ([2d51803](https://github.com/richwklein/agingdeveloper/commit/2d51803c41eb68278df92eff162cb2eb48dde914))
+- article tweaks ([bc6292c](https://github.com/richwklein/agingdeveloper/commit/bc6292c1d0e35d6f3857b57e7361e0dfde248ae2))
+- disney post ([75a2701](https://github.com/richwklein/agingdeveloper/commit/75a270153024f3f75d6d39a0c1b59bdbe4f2b9a8))
+- Bump react from 17.0.2 to 18.1.0 ([59beabd](https://github.com/richwklein/agingdeveloper/commit/59beabd1aef9b5be0e32347f511c6c58b0ea7538))
+- drop versioning header ([5759624](https://github.com/richwklein/agingdeveloper/commit/5759624c1bc158c471dfe45f198d1dc8e5d04c28))
+- fixing ([af7dcf0](https://github.com/richwklein/agingdeveloper/commit/af7dcf0508b784a0080de7ad0c8243e5ca4352c5))
+- fix deps ([6a3e6d2](https://github.com/richwklein/agingdeveloper/commit/6a3e6d21038d442158a3696362958012251e4c24))
+- try and fix deps ([551c887](https://github.com/richwklein/agingdeveloper/commit/551c8873cc5218cb5cca85d0f936450bcdef6fdb))
+- force legacy dependency resolution ([0582865](https://github.com/richwklein/agingdeveloper/commit/058286558bfb7d3de58a696be20b4e8d9be3d3a3))
+- tweaking versions ([f5533cc](https://github.com/richwklein/agingdeveloper/commit/f5533ccbc61d3e8d88c0a91cdf68872c0d0ca731))
+- try newer version of node ([54aa22b](https://github.com/richwklein/agingdeveloper/commit/54aa22bf52e97d4b7760cdf9a524f3e78ba7580e))
+- try default node and ruby ([b5c897f](https://github.com/richwklein/agingdeveloper/commit/b5c897f7e5c21cd0341479fa35fb80d57471abc3))
+- New Article ([d5970e6](https://github.com/richwklein/agingdeveloper/commit/d5970e682931e06ae5ae0165eb5a08f99a81a7db))
+- fix captialization ([922118e](https://github.com/richwklein/agingdeveloper/commit/922118edf6a4ac49d531796a13edbb95acc7c5d6))
+- tweak tense ([2c7680a](https://github.com/richwklein/agingdeveloper/commit/2c7680a2f852dab40a06b0dd0f0b0ec8c0598e26))
+- RSS Article ([b17c1cb](https://github.com/richwklein/agingdeveloper/commit/b17c1cb5f95659b569ece80eb575c27b16e9da9e))
+- Remove ignores ([369ef58](https://github.com/richwklein/agingdeveloper/commit/369ef58da2787b1f58f064ef339deb2f3918aa0a))
+- start on article ([237a64e](https://github.com/richwklein/agingdeveloper/commit/237a64e5066b8547ee85788a8928d495f2d6b0a0))
+- Upgrade to GitHub-native Dependabot ([ae596dd](https://github.com/richwklein/agingdeveloper/commit/ae596dd8f8f19b2c675b7beb78bdec1d917e6fa1))
+- Opt the website out of floc ([7189514](https://github.com/richwklein/agingdeveloper/commit/7189514f73d0fea569b31aef1f78245e8b075c08))
+- Make a PWA and add favicons ([98360af](https://github.com/richwklein/agingdeveloper/commit/98360af212fad92f504efca2c50125630efeb041))
+- upgrade minor versions ([720bbf7](https://github.com/richwklein/agingdeveloper/commit/720bbf7f5a8be2d8b7c25d44147b62288ade170d))
+- Add html to the rss feed ([1381c62](https://github.com/richwklein/agingdeveloper/commit/1381c628fff2e674e5a84345bd21bb8617cb0b17))
+- Update Dependencies ([3a080b0](https://github.com/richwklein/agingdeveloper/commit/3a080b0b36c4555080c2c34ef68cb45e6636d8a0))
+- Article on commit signing ([0d6d270](https://github.com/richwklein/agingdeveloper/commit/0d6d27092377ca425ea76ab20b90b2d74942b852))
+- Git Commit Signing Article ([791d3ff](https://github.com/richwklein/agingdeveloper/commit/791d3ff1408a73d6f3b7ffb3a76158f106f08928))
+- wip ([7698690](https://github.com/richwklein/agingdeveloper/commit/76986902ed954fcbf20ef922ece4ea88d5036229))
+- Fix publish date ([2772d2a](https://github.com/richwklein/agingdeveloper/commit/2772d2a887ee9d98b27a7631d9c3475b54a62551))
+- Article on virtual choir ([9bd913e](https://github.com/richwklein/agingdeveloper/commit/9bd913e624ba85438314894e437c59d60477824a))
+- Update packages to newest versions ([b01bf50](https://github.com/richwklein/agingdeveloper/commit/b01bf50dc66d568723f6d0bed883692519f567ad))
+- Bump eslint-config-react-app from 5.2.1 to 6.0.0 ([9a517c4](https://github.com/richwklein/agingdeveloper/commit/9a517c40e25b712135ab082b0c38030a977bcc13))
+- drop one of the links to other articles ([c76f6d8](https://github.com/richwklein/agingdeveloper/commit/c76f6d886875630336455b43ac6b9bb68199ebd1))
+- Samsung article with image tweaks ([1cce5d0](https://github.com/richwklein/agingdeveloper/commit/1cce5d0755377389d9f472f5655fe2acd86fdf94))
+- install npm globally ([aab2b65](https://github.com/richwklein/agingdeveloper/commit/aab2b6562649ca012153425f4d7282fee295e111))
+- Tweak the material-ui ([725769e](https://github.com/richwklein/agingdeveloper/commit/725769ef037168d67c33a9e7a042af36169c4e77))
+- Basic feed support without actual items yet ([7cd28eb](https://github.com/richwklein/agingdeveloper/commit/7cd28ebdd3995b8c4b63891b125453ba6e83f2b4))
+- Use more promises to parallelize more ([e1c8ef6](https://github.com/richwklein/agingdeveloper/commit/e1c8ef68ddf9eb47c60625c485a1740ef5148161))
+- remove content hashes from build ([9e06076](https://github.com/richwklein/agingdeveloper/commit/9e060764e699312585806f158a06b4713d8505d0))
+- rearrange plugin list ([671f99c](https://github.com/richwklein/agingdeveloper/commit/671f99c94cf897ad198fbcdcb5b28b7c56caa50f))
+- Enable build caching and switch to parallel page generation ([41b3cd4](https://github.com/richwklein/agingdeveloper/commit/41b3cd4718308cbb20439dfa8d112cb3ed5eb0ce))
+- fix typo ([0b997a4](https://github.com/richwklein/agingdeveloper/commit/0b997a4f2c210e6dc3329ea93c186637b6fab326))
+- Update article.js ([1956c26](https://github.com/richwklein/agingdeveloper/commit/1956c262476c533ad5cc9e28a9f1dcb9b239b864))
+- Update index.md ([fe7d36b](https://github.com/richwklein/agingdeveloper/commit/fe7d36b80a8b20e89c858983ee4044a4dfc0e52c))
+- new post on why aging developer ([0711f75](https://github.com/richwklein/agingdeveloper/commit/0711f7544c2081b104c911ebad6d703e13b32281))
+- fix description quoting on article ([219f3f9](https://github.com/richwklein/agingdeveloper/commit/219f3f9bb3e7316259528f695213d184bf3df900))
+- Add a description to the frontmatter for seo ([d9bed27](https://github.com/richwklein/agingdeveloper/commit/d9bed27972acaba5024c84c124c1b524ab8bed93))
+- ignore long line ([50c7a1f](https://github.com/richwklein/agingdeveloper/commit/50c7a1f6937e7f53c9d7f5a792c4bb4542435a49))
+- Create a custom 404 page ([204cc25](https://github.com/richwklein/agingdeveloper/commit/204cc255adc76a11a2d1777f8d538fbd20dd816c))
+- tweak the nav drawer ([4cb8400](https://github.com/richwklein/agingdeveloper/commit/4cb8400954c3213881f3e4dc2e441f3ccb56883e))
+- Fix badge causing mobile overflow issues ([2c32c67](https://github.com/richwklein/agingdeveloper/commit/2c32c67123745c2b5742b819faf081a38e145a7c))
+- New article on the author pages ([98e5ef4](https://github.com/richwklein/agingdeveloper/commit/98e5ef4abad0a42b78eab3e967690164188f556d))
+- Remove extra fragment ([16d37cd](https://github.com/richwklein/agingdeveloper/commit/16d37cd989dd0baf1e64200f117fa24ec798e07b))
+- Split tags back out ([d26f95d](https://github.com/richwklein/agingdeveloper/commit/d26f95dcd0656061b564e201f7506d79623d65e3))
+- tweak banner ([8a88049](https://github.com/richwklein/agingdeveloper/commit/8a880494d98a2a2c4a891271c5b006e0c63da7d2))
+- Finish landing the author pages ([af1d399](https://github.com/richwklein/agingdeveloper/commit/af1d3996bf513a23f7db05d16a56cbd2427c1fac))
+- Land most of the author pages work ([626131c](https://github.com/richwklein/agingdeveloper/commit/626131ce7b0f2356a9216d842416b17b178a0c4d))
+- tweaks on the way to landing author pages ([4e8beb6](https://github.com/richwklein/agingdeveloper/commit/4e8beb6e649e9f8e0a1dcee339daf70662cc7636))
+- tweak spacing more and add frontmatter settings ([bef98b6](https://github.com/richwklein/agingdeveloper/commit/bef98b6b6c94a0d5c9da4fc3d0567a40333ffb5b))
+- Adjust padding for responsive layout ([f87c9e4](https://github.com/richwklein/agingdeveloper/commit/f87c9e4525f888c5b527f142ecfc1dd60557c7dc))
+- Add new badge for articles newer than 14 days ([f3f3723](https://github.com/richwklein/agingdeveloper/commit/f3f3723de73d56e221c8008be613f1abac87ba36))
+- Add home to nav drawer ([a036dbb](https://github.com/richwklein/agingdeveloper/commit/a036dbbbd50e5b640a1c6ebe6d3d66247e438bd4))
+- Get an initial articles page done ([58200e6](https://github.com/richwklein/agingdeveloper/commit/58200e6aa7e03c608d2fcf2e7ad78ac6f085b2f4))
+- Style code using prismjs ([a499c6e](https://github.com/richwklein/agingdeveloper/commit/a499c6e727f7c10b0d029f0eb1fba249f0b8e0cf))
+- generalize the gridlist and button grids ([351b55a](https://github.com/richwklein/agingdeveloper/commit/351b55a9b06b1b4aa26e562e8e6271cb5e8734dc))
+- remove topbar padding ([82afb3e](https://github.com/richwklein/agingdeveloper/commit/82afb3eac770ba0e914c06bc80bab2c631fa782f))
+- drop breadcrumbs and reorganize ([df75fa9](https://github.com/richwklein/agingdeveloper/commit/df75fa979137231842786c68573a774e98f251aa))
+- fix up some grammer issues ([df47f4d](https://github.com/richwklein/agingdeveloper/commit/df47f4d41c4cbf59db7d6421dc5a25cd9b2cfb5f))
+- tweak wording ([d523cc5](https://github.com/richwklein/agingdeveloper/commit/d523cc55cd31a2140f1fd90c2dbbf930078fcea5))
+- tweak the last few paragraphs ([27ea239](https://github.com/richwklein/agingdeveloper/commit/27ea23904a9b1699f935f2cf37e2412296d4c6aa))
+- fix typo ([7a892be](https://github.com/richwklein/agingdeveloper/commit/7a892be06e9ae61f8260af67b86e808fbd9863e3))
+- fix typo ([d2d44c1](https://github.com/richwklein/agingdeveloper/commit/d2d44c1c95d664bc481655df6cf2123481bd1ce7))
+- Add post aboue default http config ([6e035e8](https://github.com/richwklein/agingdeveloper/commit/6e035e89c4d2db54ddd3616e7d34b8925ff04c40))
+- change how we style disabled links and fix lint issues ([48026f5](https://github.com/richwklein/agingdeveloper/commit/48026f5b20f2dd46ad8ff192406ed4a7061e454f))
+- Article on setting up a custom domain in netlify ([a8f8386](https://github.com/richwklein/agingdeveloper/commit/a8f8386c8fe6c24854f283596bccea30300c8fb8))
+- tweak the breadcrumb styling ([80c2977](https://github.com/richwklein/agingdeveloper/commit/80c2977310455020b2bb60019f88adb20cb9e187))
+- Add the category page and tweak the tag pages ([dc1952b](https://github.com/richwklein/agingdeveloper/commit/dc1952b57e7f2ff4122febf674df70a5523ca04c))
+- Uppercase tags ([9d58ab5](https://github.com/richwklein/agingdeveloper/commit/9d58ab511d1a2cc0ca9193153195a4252605a8cb))
+- Add plugin to ping search providers on publish ([6158f79](https://github.com/richwklein/agingdeveloper/commit/6158f79c5a42fd72827185fe5f7c2d4df4c5ed4f))
+- tweak tag page ([581832f](https://github.com/richwklein/agingdeveloper/commit/581832f203d4396e28d245a259030d6a6462328f))
+- Add the tag pages ([afe144d](https://github.com/richwklein/agingdeveloper/commit/afe144d3f478d70a3ea165a7aa80bab44779a9d0))
+- Trying to get the urls correct ([34d4891](https://github.com/richwklein/agingdeveloper/commit/34d489114e929a267c8d8af6c3f8e47faa2dde1f))
+- fix line length ([498f3c9](https://github.com/richwklein/agingdeveloper/commit/498f3c9e65dc83273434426201a572941aaa3dc4))
+- fix previous/next buttons ([ddb2ce3](https://github.com/richwklein/agingdeveloper/commit/ddb2ce3455ddef90bd3d273775bec5fdab190bb3))
+- fix breadcrumb ([b65ddf8](https://github.com/richwklein/agingdeveloper/commit/b65ddf8a298e2f56311ebd42fcaf602b420bc0d1))
+- fix link in false starts article ([fcb310d](https://github.com/richwklein/agingdeveloper/commit/fcb310d8bee2b5395d14382052c3ebe3f448b1c3))
+- Fix breadcrumb path ([fa26b24](https://github.com/richwklein/agingdeveloper/commit/fa26b241e190812a42a293d068a396780fd3af20))
+- Fix reditect ([29d7980](https://github.com/richwklein/agingdeveloper/commit/29d798077dc3846f3aa3199c43ac109632d592da))
+- Fix output directory ([8ee488a](https://github.com/richwklein/agingdeveloper/commit/8ee488a44ad89e9bad0770914696b3cf5c3d71c4))
+- Add file based build ([cfd3f35](https://github.com/richwklein/agingdeveloper/commit/cfd3f354d11a61d53563d9349d5e0225a5fed7b8))
+- Move the article prefix and switch to file based build ([09a5be9](https://github.com/richwklein/agingdeveloper/commit/09a5be912c0e4c777a9dfc2d911ec6a8a9d9fe7a))
+- Add breadcrumb ([5f7bb48](https://github.com/richwklein/agingdeveloper/commit/5f7bb481718d5d6e8101a55d124d16f0b930f303))
+- Add comments and tweak article layout ([29ce5f3](https://github.com/richwklein/agingdeveloper/commit/29ce5f374ab0cc834b93c08004c88e7bbc9745c0))
+- embed path prefix in article url ([91d2e3e](https://github.com/richwklein/agingdeveloper/commit/91d2e3e23e5c1b24e66cc27935482ec4c327c6f9))
+- Reorder nav bar ([859529a](https://github.com/richwklein/agingdeveloper/commit/859529a3fc1640f88e4aa1b57614739f44aecb63))
+- Add view all button and move articles to article path prefix ([e238260](https://github.com/richwklein/agingdeveloper/commit/e238260338a53651513d3b64d6d590080af2a55c))
+- Fix image sizes on article page on mobile ([d742412](https://github.com/richwklein/agingdeveloper/commit/d742412a143bbd51ae9745f8099f34f63bc09fe6))
+- Land SEO headers ([cf00e88](https://github.com/richwklein/agingdeveloper/commit/cf00e885d9d64ffafd35d80bf17062144897d6af))
+- Issue #27 explain content location ([0579bed](https://github.com/richwklein/agingdeveloper/commit/0579bedfe1de57d9bcd0d6c5e303d24629570d58))
+- Add smoe more lint rules ([5926020](https://github.com/richwklein/agingdeveloper/commit/59260203fd2bad758ce58df5cd981d60b10c4d7c))
+- Adding vscode settings to the workspace ([069c2cb](https://github.com/richwklein/agingdeveloper/commit/069c2cb6e6f483ffd6e4d5a25797fe104142b725))
+- Specifying a ci build ([4293bcb](https://github.com/richwklein/agingdeveloper/commit/4293bcb96c0ec190afa83557392fb597ec9a302f))
+- Specifying a ci build ([43bc710](https://github.com/richwklein/agingdeveloper/commit/43bc7106e53a369b1a78f6a1a0967c67a3d8921d))
+- Update false-start.md ([c0f85db](https://github.com/richwklein/agingdeveloper/commit/c0f85db41c68b32214d9d8a70e49e31ca86ef485))
+- Tweak the avatar display ([dae3745](https://github.com/richwklein/agingdeveloper/commit/dae3745ad0607e22eb6f4533d908fd7cdcd34400))
+- Formatting fixes ([4302530](https://github.com/richwklein/agingdeveloper/commit/4302530b04e510104c25eee6fe1058feedd9fe78))
+- Formatting fixes ([b2bc23f](https://github.com/richwklein/agingdeveloper/commit/b2bc23f4491e136f00a9425c44c5bb9882d38e50))
+- test ([5b8b7a0](https://github.com/richwklein/agingdeveloper/commit/5b8b7a05568810be5d90e33e57cbef26bf6d0561))
+- Formatting fixes ([1e6bd4e](https://github.com/richwklein/agingdeveloper/commit/1e6bd4e724046f7dc75f4054065dd679fa8bbc96))
+- Fix eslint formatting ([82e89e6](https://github.com/richwklein/agingdeveloper/commit/82e89e64ef029e8f66ade6ff49d34ac0d81e5da3))
+- Fix formatting based on eslint ([83c5011](https://github.com/richwklein/agingdeveloper/commit/83c501145b3726fb381daa4f91d732a71f10fca9))
+- switch to using eslint instead of prettier and use the google styles ([1931048](https://github.com/richwklein/agingdeveloper/commit/1931048836ecd63cd665ef991d3f23eb009c3918))
+- Switch from prettier to eslint and use google's rules ([271e003](https://github.com/richwklein/agingdeveloper/commit/271e0031a4053ecad30bc246c752790cfdb69f79))
+- fix index title ([6e7a808](https://github.com/richwklein/agingdeveloper/commit/6e7a808d2e95ab60374f3c1373225df9fec88392))
+- Second article with fixes for image sizes and titles ([2bfb01c](https://github.com/richwklein/agingdeveloper/commit/2bfb01cdd5ce3ff0b00f57dba30f0a0884a91236))
+- Make components as standalone as possible and update the theme ([9a908cc](https://github.com/richwklein/agingdeveloper/commit/9a908cc20df2b3d2416516378cf9cd2b68cf4e20))
+- blah ([bf1c0f8](https://github.com/richwklein/agingdeveloper/commit/bf1c0f88473b26f8215dc68b9e7a1575d3084416))
+- More work on the author page ([1190ae5](https://github.com/richwklein/agingdeveloper/commit/1190ae50453bd047473af75c9e1ac708419c1acf))
+- Moving scroll logic into layout ([1ecc892](https://github.com/richwklein/agingdeveloper/commit/1ecc892dbf50e218126afccffd7b47ef9126eb61))
+- Moving scroll logic within layout ([332b0f8](https://github.com/richwklein/agingdeveloper/commit/332b0f8a686bfcd40fd99a721514dbce3c413688))
+- Moving scroll logic into layout ([f72e8e5](https://github.com/richwklein/agingdeveloper/commit/f72e8e560bce8604643bf7cb348ae76643b20ef1))
+- Moving scroll logic into layout component ([9c6d6ce](https://github.com/richwklein/agingdeveloper/commit/9c6d6ce16fe97deda23982eaf3d62f2443d65d66))
+- Move scroll logic into layout ([5105737](https://github.com/richwklein/agingdeveloper/commit/510573784cb400cb9c192fb6e4c29f011a0612a6))
+- Move scrolling into layout and fix ([5524430](https://github.com/richwklein/agingdeveloper/commit/5524430adf7d3009b835752eafa57a9aeba8211e))
+- Fix scrolling to top ([7193b80](https://github.com/richwklein/agingdeveloper/commit/7193b80a12e0dfda675d89a0b333fc12a19faeeb))
+- Start getting author setup ([95a9b5b](https://github.com/richwklein/agingdeveloper/commit/95a9b5bdcbb36bc196680d306cd38a951a8491b5))
+- add link to image ([ac22e73](https://github.com/richwklein/agingdeveloper/commit/ac22e73a0e3df0edf607742ef1392d1d0c5f23a6))
+- Change date format on article card ([5259af6](https://github.com/richwklein/agingdeveloper/commit/5259af6a07425af61d83cd48752c89c1688cb909))
+- Darken the text in the banner ([a7da6bf](https://github.com/richwklein/agingdeveloper/commit/a7da6bfbe0de08b7e02c3e10c0f5de24ef7fa86e))
+- Change the grey color ([8dae2ce](https://github.com/richwklein/agingdeveloper/commit/8dae2ce25f518b23407f84c15b5261b0f087e6f8))
+- Change grid spacing on banner ([f623bdd](https://github.com/richwklein/agingdeveloper/commit/f623bddf56962be9b1039b418dcb484cc4ca6fd8))
+- Get rough draft of home done ([cbeeba1](https://github.com/richwklein/agingdeveloper/commit/cbeeba197f4dcd690f51429756bae94625f7b244))
+- Update intro.md ([11ee501](https://github.com/richwklein/agingdeveloper/commit/11ee501ce7f814dfcb97018239f524db6e1a9c4c))
+- Update intro.md ([2627012](https://github.com/richwklein/agingdeveloper/commit/26270128666d37170445e37ea9e84989b6edb44d))
+- Add a colon to the warning ([781b8ab](https://github.com/richwklein/agingdeveloper/commit/781b8ab3bbe40acc50c3a42087f07b7a1cc3025b))
+- Update gatsby-node.js ([edb34cc](https://github.com/richwklein/agingdeveloper/commit/edb34cc132a2922493c5427da30cec5d5aa684fd))
+- update the intro post ([6a53bb7](https://github.com/richwklein/agingdeveloper/commit/6a53bb75dab58b308ec902ad258cb25967ba9813))
+- change the file name and url ([c604698](https://github.com/richwklein/agingdeveloper/commit/c6046981ad40a5cb4368762d88b880f9ce165804))
+- Get the first post in the books ([6c4c83a](https://github.com/richwklein/agingdeveloper/commit/6c4c83a2c35fe6950514b09bb035c9b62dc1567b))
+- Get article pages working ([2b363a6](https://github.com/richwklein/agingdeveloper/commit/2b363a67b9ea55401271e981bc74c1207178ec38))
+- Get the footer working ([1d45d9e](https://github.com/richwklein/agingdeveloper/commit/1d45d9e1bdc3da48dc4064294beb3a799ba00da9))
+- Add site navigation ([a0922ba](https://github.com/richwklein/agingdeveloper/commit/a0922ba8f48799a2849950ae9660e81d45100e2f))
+- Add keybase signature to show site ownership ([aedcdba](https://github.com/richwklein/agingdeveloper/commit/aedcdba8db8a5ddc50b50a9f5de47c156832276a))
+- Use a close button for the nav drawer ([c40400f](https://github.com/richwklein/agingdeveloper/commit/c40400f0333809c853646d7312d806a51d289975))
+- wip ([75b9d12](https://github.com/richwklein/agingdeveloper/commit/75b9d12f2494e5d36bb2cd2fdcd730340e0aa267))
+- set the typography and prefetch google fonts ([08bb726](https://github.com/richwklein/agingdeveloper/commit/08bb726b2344a995d96ad909c4cf4a254e4aa40c))
+- fix fousc ([5add831](https://github.com/richwklein/agingdeveloper/commit/5add8310f04176a73b16714abaff84e587bb9127))
+- tweak readme license info ([dfe545a](https://github.com/richwklein/agingdeveloper/commit/dfe545ab2805e6bf7170fe4b65631d3d830b4d08))
+- tweak readme ([404d26f](https://github.com/richwklein/agingdeveloper/commit/404d26f43f274292e9171e51e6ebaad2c19b5214))
+- Start landing where I'm at ([592c296](https://github.com/richwklein/agingdeveloper/commit/592c296a9cec21c8401507d418ff517de955aeb6))
+- Get the footer back in ([a01c7f1](https://github.com/richwklein/agingdeveloper/commit/a01c7f1608d6fe6545143bfe3e107575d0de1ec6))
+- cleanup ([e638024](https://github.com/richwklein/agingdeveloper/commit/e638024fea9d90e9a75e9f6a688c6542eb77875e))
+- ignore the package-lock file ([bb3af09](https://github.com/richwklein/agingdeveloper/commit/bb3af0985bb2a5e230596dd7a9299026b81ea1a6))
+- do not commit package-lock ([778897a](https://github.com/richwklein/agingdeveloper/commit/778897a7d7d421e849dcf33e6210df344164c0b1))
+- Trying to get a working build ([fbf0e7e](https://github.com/richwklein/agingdeveloper/commit/fbf0e7e001c5f16d71abbd1bb1ca3dedee155888))
+- still building ([14657c4](https://github.com/richwklein/agingdeveloper/commit/14657c4ac49a98c544e0832dcf5143749ed3e5f8))
+- find the footer ([07d0ac8](https://github.com/richwklein/agingdeveloper/commit/07d0ac8adac2f458c641bb0c1bdbf37fae53e62c))
+- Building ([12932d1](https://github.com/richwklein/agingdeveloper/commit/12932d1a25d910f3ed6b88c73bc37db799bb49e4))
+- Get netlify build working again ([e914aaf](https://github.com/richwklein/agingdeveloper/commit/e914aaf943cb90e23607c802b72c7a2377b8b0d3))
+- Trying to get builds working ([f633dd8](https://github.com/richwklein/agingdeveloper/commit/f633dd8ddc18d52db486034ca2560dbd033e48ff))
+- landing material design change ([2ac73a7](https://github.com/richwklein/agingdeveloper/commit/2ac73a711033f3a8fd5089d8c45917948c231dcf))
+- fix ssr ([434577f](https://github.com/richwklein/agingdeveloper/commit/434577fed2be7d1fd1d566bcbe5e8e2ccef8c91d))
+- Get theme colors set ([0becb1e](https://github.com/richwklein/agingdeveloper/commit/0becb1e77fde0a349deb8efee5210eebb55bb5b5))
+- commit the package-lock.json ([1bfe74b](https://github.com/richwklein/agingdeveloper/commit/1bfe74b4953053ae115874e468b669512115069b))
+- setup browser and ssr ([6ae685f](https://github.com/richwklein/agingdeveloper/commit/6ae685f3dedf445c5b681a0cf38d1635e793b05d))
+- Update the readme and remove the old mocks ([e677c2b](https://github.com/richwklein/agingdeveloper/commit/e677c2b4a5f16a492c59610ced1389dd7d9ce262))
+- Basic layout in place ([82a1343](https://github.com/richwklein/agingdeveloper/commit/82a1343151b6823d7f9236e49c8c3053ba9221a3))
+- Layout fixes ([d3fdd97](https://github.com/richwklein/agingdeveloper/commit/d3fdd972c5dc97881f4e616569968e2ab0fce713))
+- fix up make file ([a59f796](https://github.com/richwklein/agingdeveloper/commit/a59f7968a8e18f7d76885767835de6776f02b4fb))
+- netlify is still throwing errors ([116730a](https://github.com/richwklein/agingdeveloper/commit/116730aebb3577f046bf0626bd8be6c423ff27d0))
+- still trying to get it working ([264a59e](https://github.com/richwklein/agingdeveloper/commit/264a59e41cbea1556cacca322ec9b47ec2c34018))
+- Fix up the make files ([8ed9463](https://github.com/richwklein/agingdeveloper/commit/8ed9463c05bafc7416b60a85fb621fc802745aa5))
+- enable incremental builds ([c3d70d9](https://github.com/richwklein/agingdeveloper/commit/c3d70d9383592f333b7afba75f4513ec338eecc8))
+- Bump prettier from 2.0.4 to 2.0.5 ([4d54195](https://github.com/richwklein/agingdeveloper/commit/4d54195ce9e2cc42a789109e0f2b0247e68ad0fe))
+- Bump prettier from 2.0.3 to 2.0.4 ([14693b6](https://github.com/richwklein/agingdeveloper/commit/14693b606ac9ccd5f7258da8bc951553135def1a))
+- Bump prettier from 2.0.2 to 2.0.3 ([ee0c52a](https://github.com/richwklein/agingdeveloper/commit/ee0c52afe12bafe005a39b2115985b9900ece49d))
+- Bump prettier from 2.0.1 to 2.0.2 ([f922046](https://github.com/richwklein/agingdeveloper/commit/f9220463a1a0d7567d625c053eb3bc2f050bce02))
+- Bump prettier from 1.19.1 to 2.0.1 ([c52f0cd](https://github.com/richwklein/agingdeveloper/commit/c52f0cdb5b48483f09ca766605a94b9941c1cac8))
+- Add a markdown file to fix build ([fc900ed](https://github.com/richwklein/agingdeveloper/commit/fc900edd6d9deec721352f631600897621e489e1))
+- Updated layout ([12b020a](https://github.com/richwklein/agingdeveloper/commit/12b020a15a80d59a2109b39ea9f19ed3372b8922))
+- Update the styling to improve it. ([a04dcd8](https://github.com/richwklein/agingdeveloper/commit/a04dcd81a62841e53304c15648568e2b4793a46f))
+- Add a 404 page ([884c3cc](https://github.com/richwklein/agingdeveloper/commit/884c3ccb23e135d07ae4356e7f453362001a9d46))
+- Remove adsense ([55ab42d](https://github.com/richwklein/agingdeveloper/commit/55ab42d0494aae87a07ed0e66f9e060195f40271))
+- Set up analytics and ads ([35fcc90](https://github.com/richwklein/agingdeveloper/commit/35fcc90a68f3563d24670e4d122aa65a7fc5adfa))
+- fix robots.txt ([7634dae](https://github.com/richwklein/agingdeveloper/commit/7634daecb92eb908ed507fae6879910737f4064b))
+- fix robots.txt ([5a5f3b0](https://github.com/richwklein/agingdeveloper/commit/5a5f3b0a5a8e0fbd81decb9874ab7cfa0f589f5f))
+- fix robots.txt ([175365c](https://github.com/richwklein/agingdeveloper/commit/175365cc13a62b0439aa009706c014926305d2a9))
+- Add site navigation ([79a2053](https://github.com/richwklein/agingdeveloper/commit/79a2053da029009e05f29fc51de7e70618562b2b))
+- Fix makefile and simplfy gatsby-config ([ce2e9c2](https://github.com/richwklein/agingdeveloper/commit/ce2e9c26d26343bba4a8373cfcd6e466a4913abc))
+- Fix makefile and simplfy gatsby-config ([cbdb7ad](https://github.com/richwklein/agingdeveloper/commit/cbdb7ad7fcebed6b32d0b7e3ed3ac12454ffef19))
+- Set up canonical urls ([5a9e323](https://github.com/richwklein/agingdeveloper/commit/5a9e323db2fe50e6b839106203d8a42ebb778f38))
+- Set up makefile and move todos to github issues ([49595b9](https://github.com/richwklein/agingdeveloper/commit/49595b97edaadb30cbe9b7d75985f2b2fb194a33))
+- Move the table of contents ([c426c39](https://github.com/richwklein/agingdeveloper/commit/c426c395bf56949dcec70c468d454c7b333e4009))
+- Move the table of contents ([5283668](https://github.com/richwklein/agingdeveloper/commit/52836684ed8a87e682d923071059adaf055cb98d))
+- Move the table of contents ([9ddea92](https://github.com/richwklein/agingdeveloper/commit/9ddea9206ac8aaa95889ad2561fcf05af7a07ba8))
+- Move the table of contents ([730bfc6](https://github.com/richwklein/agingdeveloper/commit/730bfc6b9a244bcd5a3aee160518c2263b30d18d))
+- Move the table of contents ([b6e779b](https://github.com/richwklein/agingdeveloper/commit/b6e779b9e4847448c0cc801f52445ee73e7b76ee))
+- change path to mocks ([622203e](https://github.com/richwklein/agingdeveloper/commit/622203e86a3ef376c32792b77e5ad686f0d7b2a8))
+- fix path to license ([32d097a](https://github.com/richwklein/agingdeveloper/commit/32d097aad620109d20165d5b13cb373e1884c530))
+- Define Licensing ([f8ff285](https://github.com/richwklein/agingdeveloper/commit/f8ff285b6c8080742f3cfb55a5f892e6f4eb7ce1))
+- Add sitemap and robots files ([1425b1d](https://github.com/richwklein/agingdeveloper/commit/1425b1db300420171d20dd8389f76beeac295dc8))
+- Add sitemap and robots files ([cb85297](https://github.com/richwklein/agingdeveloper/commit/cb8529784e4ed578b2d5af34db4ce8b55f3bdc46))
+- Initial Titlebar implementation ([b0c825a](https://github.com/richwklein/agingdeveloper/commit/b0c825a94357788397d62318561bf094098826e5))
+- Update gitignore to include package-lock ([4a712bd](https://github.com/richwklein/agingdeveloper/commit/4a712bd0bc759385ae6b35b6e68e91ea769e0eb7))
+- Remove package-lock.json from repo ([47c6a40](https://github.com/richwklein/agingdeveloper/commit/47c6a405ae72148c27ce677e6b7bbcd8ca849217))
+- Set up code owners ([64d2b2e](https://github.com/richwklein/agingdeveloper/commit/64d2b2ef7157e930729852dcaa100960f3fec288))
+- Prettify code and fix lint issues ([cae99a4](https://github.com/richwklein/agingdeveloper/commit/cae99a458daefb2b5bbc0ebb9a829e39892eb056))
+- Prettify code and fix lint issues ([a3939b4](https://github.com/richwklein/agingdeveloper/commit/a3939b45d198e3bf72fcf1ad4aa9b109e23d7e5f))
+- Prettify code and fix lint issues ([4cf70f5](https://github.com/richwklein/agingdeveloper/commit/4cf70f5b9ebd832e024799a0d5cf45f5e8a907c8))
+- Prettify code and fix lint issues ([89f7b14](https://github.com/richwklein/agingdeveloper/commit/89f7b1414cfdc52f385ba8fe4914ddf1c831d007))
+- Make the move to an empty gatsby project ([f5543bb](https://github.com/richwklein/agingdeveloper/commit/f5543bb43afcce53a681aa07dd9bda6c1fd5360e))
+- Tweaking the readme ([b03a4aa](https://github.com/richwklein/agingdeveloper/commit/b03a4aa2df2205d2647da2ca58fe23d1d1a1c7ee))
+- Tweaking the readyme ([eba1445](https://github.com/richwklein/agingdeveloper/commit/eba14454e65ca2a5549306f80ec80139391565e7))
+- Tweaking the readme file ([25e0c0c](https://github.com/richwklein/agingdeveloper/commit/25e0c0c03fd0df1884d64ee93c5f6e612078cd39))
+- Update README.md ([a7f10aa](https://github.com/richwklein/agingdeveloper/commit/a7f10aa0faa412f1593081e0508e956461769e7f))
+- Update README.md ([b880597](https://github.com/richwklein/agingdeveloper/commit/b8805978fbae38e8ad2c561133ad35fb6f320c33))
+- Update README.md ([8483d6b](https://github.com/richwklein/agingdeveloper/commit/8483d6b815ea55102c8fdab7d60dfb9be98302c6))
+- Update the readme ([017ebb9](https://github.com/richwklein/agingdeveloper/commit/017ebb9ade668b4fd8eb045fc8bd4e68a7e9d4f5))
+- More cleanup ([a41580d](https://github.com/richwklein/agingdeveloper/commit/a41580d40c7c97dafd3e383f51b7a7e83b5af123))
+- Remove dead content ([90ce3bb](https://github.com/richwklein/agingdeveloper/commit/90ce3bb7f12da9428e561d8263da311b94a0cc49))
+- Updates to gitignore and jshint ([1f12a99](https://github.com/richwklein/agingdeveloper/commit/1f12a99af178cadb9c743d8e57617f732a4cf8df))
+- Site metadata ([6c4aec2](https://github.com/richwklein/agingdeveloper/commit/6c4aec25b95b4386d71e2b2e7717dbb714068c11))
+- Cleaning up gitignore ([569ea39](https://github.com/richwklein/agingdeveloper/commit/569ea398d86a9b2c95b0207d5e5e3dd4474907e7))
+- Initial commit from gatsby: (git@github.com:gatsbyjs/gatsby-starter-blog.git) ([aa43efc](https://github.com/richwklein/agingdeveloper/commit/aa43efc279b570c4469b9634468350df79efe72e))

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,8 @@
       "release-type": "node",
       "package-name": "agingdeveloper",
       "changelog-path": "CHANGELOG.md",
-      "include-v-in-tag": true,
+      "include-v-in-tag": false,
+      "include-component-in-tag": false,
       "bump-minor-pre-major": false,
       "draft": false,
       "prerelease": false


### PR DESCRIPTION
## Summary

Seeds `CHANGELOG.md` with historical release notes covering all 117 git tags (2.1.0 → 6.8.1) and fixes a tag-format mismatch in `release-please-config.json` that caused release-please to misread the project's release history.

## Linked issue

Closes #

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Maintenance / cleanup
- [x] Documentation / content
- [ ] Breaking change

## Details

**Why the config change.** The previous config produced release tags of the form `agingdeveloper-v<version>`, but existing tags in this repo are plain `<version>` (e.g., `6.8.1`). Because release-please couldn't find any prior release tag matching its expected format, it treated the entire git history as unreleased — which is why PR #916 proposed a 6.9.0 bump and a CHANGELOG entry replaying commits already shipped under tags 6.3.1, 6.4.0, 6.5.0, 6.6.1, and 6.7.0.

Setting `include-component-in-tag: false` and `include-v-in-tag: false` makes release-please look for tag `6.8.1`, which it finds, and constrains future changelogs to commits since that tag.

**CHANGELOG generation.** I walked every tag chronologically, diffed commits between adjacent tags, parsed conventional commit prefixes (`feat`, `fix`, `perf`, etc.) from both subject and (for merge commits) body, and grouped each release's commits into release-please-style sections:
- Features / Bug Fixes / Performance Improvements / Reverts
- Miscellaneous Changes (for non-conventional commits like quote-of-the-week and content updates)

Every tagged release has an entry so the file is a complete record.

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] This PR intentionally updates the version

After this lands, please close PR #916 — it was created from the misread history and would otherwise cut a misleading 6.9.0 release. The next release-please run (post-merge) will find tag `6.8.1`, see only `chore:` commits since, and stay quiet until something user-facing lands.

## Validation

- [ ] Lint passes locally
- [ ] Unit tests pass locally
- [ ] Added or updated tests where appropriate
- [x] Manually verified changes
- [ ] Documentation updated where appropriate

Manual verification: confirmed all 117 tags appear in CHANGELOG.md and spot-checked entries against `git log` for several releases (6.5.0, 6.0.0, 5.0.0, 4.0.0).

## Reviewer notes

The CHANGELOG is large (~1100 lines) because of the long tag history. The diff against main is essentially "new file + 1-line config change". Worth skimming the top entries (6.x) to sanity-check formatting; older entries follow the same shape.