### PR TITLE
chore(weekly-quote): adopt release-please + add May 18 quote

### DIFF
--- a/.claude/commands/weekly-quote.md
+++ b/.claude/commands/weekly-quote.md
@@ -1,5 +1,5 @@
 ---
-description: Add the weekly chalkboard quote to quote.json and cut a patch release
+description: Add the weekly chalkboard quote to quote.json (release-please cuts the patch release from the commit)
 ---
 
 You are helping add the weekly chalkboard quote for the agingdeveloper site.
@@ -76,11 +76,7 @@ With source:
 
 Insert the new entry as the **first element** of the array in `src/content/data/quote.json`.
 
-## Step 5 — Bump the patch version
-
-Increment the patch segment of `version` in `package.json` (e.g. `6.6.4` → `6.6.5`).
-
-## Step 6 — Lint and format
+## Step 5 — Lint and format
 
 Run the repository fix and verify scripts:
 
@@ -91,3 +87,17 @@ npm run verify
 ```
 
 Surface any failures clearly before finishing.
+
+## Step 6 — Commit message
+
+**Do not bump `package.json` manually.** release-please owns versioning and will open a release PR based on the commit message.
+
+Suggest a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) message in this form so release-please cuts a patch release:
+
+```
+fix(quote): add weekly quote for <Month D, YYYY>
+```
+
+Example: `fix(quote): add weekly quote for May 18, 2026`
+
+Do not commit unless the user asks.

--- a/src/content/data/quote.json
+++ b/src/content/data/quote.json
@@ -1,5 +1,16 @@
 [
   {
+    "id": "98f07411-e7f4-43c5-bf55-1480228261cb",
+    "text": "Ohana means family. Family means nobody gets left behind, or forgotten.",
+    "author": "Lilo",
+    "chalked": "2026-05-18",
+    "source": {
+      "title": "Lilo & Stitch",
+      "type": "movie",
+      "year": 2002
+    }
+  },
+  {
     "id": "7b77ebe4-13c6-4a3a-82d2-61bc3eb19920",
     "text": "No matter how far we come, our parents are always in us.",
     "author": "Brad Meltzer",


### PR DESCRIPTION
## Summary

Two related changes:

1. Drop the manual `package.json` patch-bump step from the `/weekly-quote` command and document the `fix(quote): …` Conventional Commit that release-please uses to cut the release.
2. Add this week's chalkboard quote (May 18, 2026).

## Linked issue

Closes #

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Maintenance / cleanup
- [x] Documentation / content
- [ ] Breaking change

## Details

- `.claude/commands/weekly-quote.md`: removed the manual version-bump step; added a Step 6 documenting the `fix(quote): add weekly quote for <Month D, YYYY>` commit convention; updated the front-matter description.
- `src/content/data/quote.json`: prepended this week's entry — _"Ohana means family. Family means nobody gets left behind, or forgotten."_ — Lilo (*Lilo & Stitch*, 2002), `chalked: 2026-05-18`.

## Release / deploy impact

- [x] Preview deploy is useful for reviewing this change
- [ ] Safe to label `no-deploy`
- [ ] This PR intentionally updates the version

The `fix(quote): …` commit is expected to trigger a release-please patch-bump PR on merge. This is the first weekly-quote PR under the new release-please workflow — worth confirming the release PR opens as expected.

## Validation

- [x] Lint passes locally
- [x] Unit tests pass locally
- [ ] Added or updated tests where appropriate
- [x] Manually verified changes
- [ ] Documentation updated where appropriate

`npm run lint:fix`, `npm run format:fix`, and `npm run verify` (lint + format-check + tests + build) all passed locally.

## Reviewer notes

The two commits are intentionally split so the `fix(quote): …` commit cleanly carries the patch-release signal for release-please, while the workflow update lands as `chore`.
