### PR TITLE
chore(prettier): ignore CHANGELOG.md and .release-please-manifest.json

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,10 @@
 # Canonical Contributor Covenant text — never reformat or it diverges from upstream.
 CODE_OF_CONDUCT.md
 
+# Release-please writes these in its own format; do not let prettier touch them.
+CHANGELOG.md
+.release-please-manifest.json
+
 # Generated / build / cache directories
 .astro/
 dist/


### PR DESCRIPTION
## Summary

Adds `CHANGELOG.md` and `.release-please-manifest.json` to `.prettierignore`. release-please writes these files in its own format, which conflicts with prettier's defaults — caused a failing lint check on the release PR in [richwklein/agingdeveloper#921](https://github.com/richwklein/agingdeveloper/pull/921).

## Type of change

- [x] Maintenance / cleanup

## Details

release-please owns:

- `CHANGELOG.md` — strict markdown structure with version headers, compare URLs, categorized commits
- `.release-please-manifest.json` — internal version tracking

Prettier disagrees with both (bullet style, blank-line placement, JSON formatting). Adding both to `.prettierignore` so release-please PRs pass lint without manual fixup.

## Release / deploy impact

- [x] Safe to label `no-deploy`

## Validation

- [x] Manually verified changes