### PR TITLE
feat(release): use GitHub App token in tag-release.yaml

### DIFF
--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -17,10 +17,18 @@ jobs:
       release_tag: ${{ steps.release.outputs.tag_name }}
 
     steps:
+      - name: 'Generate App token'
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
       - name: 'Run release-please'
         id: release
         uses: googleapis/release-please-action@v4
         with:
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
## Summary

Mirrors [richwklein/repo-template-astro#14](https://github.com/richwklein/repo-template-astro/pull/14). On this repo, release-please is integrated into `tag-release.yaml` rather than living in a standalone `release-please.yaml`, so the change is in the `release-please` job inside that workflow.

## Type of change

- [x] Feature

## Details

Adds `actions/create-github-app-token@v1` step before the existing `Run release-please` step. Same App token is then passed to `release-please-action@v4`. The downstream `code-build` / `publish-release` / `lighthouse` jobs are unchanged.

Secrets `RELEASE_BOT_APP_ID` and `RELEASE_BOT_PRIVATE_KEY` already in place.

## Release / deploy impact

- [x] Safe to label `no-deploy`

This is a workflow restructure on the tag-release job. Production deploys only fire when release-please actually cuts a release (`release_created == true`), same as before.

## Validation

- [x] Workflow YAML valid