### PR TITLE
fix(quote): add weekly quote for May 25, 2026

### DIFF
--- a/src/content/data/quote.json
+++ b/src/content/data/quote.json
@@ -1,5 +1,16 @@
 [
   {
+    "id": "8ff716e6-c718-4cc8-8af7-d4038406cb77",
+    "text": "A hero is someone who has given his or her life to something bigger than oneself.",
+    "author": "Joseph Campbell",
+    "chalked": "2026-05-25",
+    "source": {
+      "title": "The Power of Myth",
+      "type": "book",
+      "year": 1988
+    }
+  },
+  {
     "id": "98f07411-e7f4-43c5-bf55-1480228261cb",
     "text": "Ohana means family. Family means nobody gets left behind, or forgotten.",
     "author": "Lilo",


### PR DESCRIPTION
## Summary

Adds the weekly chalkboard quote for May 25, 2026 (Memorial Day). The quote is from Joseph Campbell's *The Power of Myth* (1988):

> "A hero is someone who has given his or her life to something bigger than oneself."

## Linked issue

Closes #

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Maintenance / cleanup
- [x] Documentation / content
- [ ] Breaking change

## Details

Prepends a new entry to `src/content/data/quote.json` with a fresh UUID, the quote text, author, chalked date, and source metadata. No other files were changed.

## Release / deploy impact

- [x] Preview deploy is useful for reviewing this change
- [ ] Safe to label `no-deploy`
- [ ] This PR intentionally updates the version

## Validation

- [x] Lint passes locally
- [x] Unit tests pass locally
- [ ] Added or updated tests where appropriate
- [x] Manually verified changes
- [ ] Documentation updated where appropriate

## Reviewer notes

release-please will cut a patch release from the `fix(quote):` commit message on merge.
