### PR TITLE
chore(audit): sync CONTRIBUTING and tag-release with template

### DIFF
--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -1,3 +1,5 @@
+# Supersedes repo-template-astro's release-please.yaml: runs release-please then
+# chains build → Netlify production deploy → Lighthouse on every release.
 name: 'Tag Release'
 
 on:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ docs: clarify deployment steps
 
 ## Branching and PRs
 
-- `main` is protected by a ruleset (see [`docs/BRANCH_PROTECTION.md`](docs/BRANCH_PROTECTION.md)).
+- `main` is protected by a ruleset.
 - Work happens on feature branches. PRs only — no direct pushes to `main`.
 - Merges must be squash or rebase. No merge commits.
 - Branch must be up to date with `main` before merging (strict status checks).


### PR DESCRIPTION
## Summary

- Remove stale `docs/BRANCH_PROTECTION.md` link from `CONTRIBUTING.md` — the link was added in an earlier template revision but has since been removed from the template
- Add comment to `tag-release.yaml` noting it supersedes the template's `release-please.yaml` (prevents false-positive audit findings)

## Test plan

- [ ] CI passes
- [ ] `CONTRIBUTING.md` line 22 reads `` - `main` is protected by a ruleset. `` without the docs link
- [ ] `tag-release.yaml` has the supersedes comment at the top

🤖 Generated with [Claude Code](https://claude.com/claude-code)