### PR TITLE
chore(release): normalize tag format to v-prefix

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,7 @@
       "release-type": "node",
       "package-name": "agingdeveloper",
       "changelog-path": "CHANGELOG.md",
-      "include-v-in-tag": false,
+      "include-v-in-tag": true,
       "include-component-in-tag": false,
       "bump-minor-pre-major": false,
       "draft": false,


### PR DESCRIPTION
## Summary

- Sets `include-v-in-tag: true` in `release-please-config.json` so all future releases use the standard `v{version}` tag format
- Bootstrap tag `v6.10.1` already created at the same commit as the existing bare `6.10.1` tag so release-please has a valid anchor
- Historical bare tags (`6.x.x`) are left as-is; only future releases will use the `v` prefix

## Test plan

- [ ] Merge this PR
- [ ] Verify the tag-release workflow runs without error
- [ ] Confirm the next release PR uses a `v6.10.x` tag name (not bare `6.10.x`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)