### PR TITLE
fix(quote): add weekly quote for June 1, 2026

### DIFF
--- a/src/content/data/quote.json
+++ b/src/content/data/quote.json
@@ -1,5 +1,16 @@
 [
   {
+    "id": "bdf23111-ef3a-40c2-8f7c-bf3cc291a3b9",
+    "text": "It was June, and the world smelled of roses.",
+    "author": "Maud Hart Lovelace",
+    "chalked": "2026-06-01",
+    "source": {
+      "title": "Betsy-Tacy and Tib",
+      "type": "book",
+      "year": 1941
+    }
+  },
+  {
     "id": "8ff716e6-c718-4cc8-8af7-d4038406cb77",
     "text": "A hero is someone who has given his or her life to something bigger than oneself.",
     "author": "Joseph Campbell",


### PR DESCRIPTION
## Summary

Adds the weekly chalkboard quote for June 1, 2026. Quote is from Maud Hart Lovelace's *Betsy-Tacy and Tib* (1941):

> "It was June, and the world smelled of roses."

## Linked issue

Closes #

## Type of change

_Put an `x` in the boxes that apply._

- [ ] Bug fix
- [ ] Feature
- [ ] Maintenance / cleanup
- [x] Documentation / content
- [ ] Breaking change

## Details

Prepended a new entry to `src/content/data/quote.json` with a fresh UUID, `chalked` date of `2026-06-01`, and a verified source object (`book`, 1941).

## Release / deploy impact

_Put an `x` in the boxes that apply._

- [x] Preview deploy is useful for reviewing this change
- [ ] Safe to label `no-deploy`
- [ ] This PR intentionally updates the version

## Validation

_Put an `x` in the boxes that apply._

- [x] Lint passes locally
- [x] Unit tests pass locally
- [ ] Added or updated tests where appropriate
- [x] Manually verified changes
- [ ] Documentation updated where appropriate

## Reviewer notes

release-please will cut a patch release from the `fix(quote):` commit type once this merges to main.