### PR TITLE
chore(audit): sync detect-relevant-changes action and update PR workflows

### DIFF
--- a/.github/actions/detect-relevant-changes/action.yaml
+++ b/.github/actions/detect-relevant-changes/action.yaml
@@ -1,0 +1,69 @@
+name: 'Detect Relevant Changes'
+description: >
+  For pull_request events, sets relevant=true when any changed file matches one
+  of the supplied regex patterns. For any other event (push, schedule,
+  workflow_run, etc.) sets relevant=true unconditionally so heavy work is
+  preserved on main branch and scheduled runs.
+
+inputs:
+  patterns:
+    description: >
+      Multi-line list of JavaScript-compatible regex patterns matched against
+      the full path of each changed file. When empty, falls back to a default
+      set covering JS/TS/Astro source, Markdown, common configs, package
+      manifests, workflow/action edits, and .tool-versions.
+    required: false
+    default: ''
+
+outputs:
+  relevant:
+    description: 'true when heavy steps should run; false when the job should noop'
+    value: ${{ steps.detect.outputs.relevant }}
+
+runs:
+  using: 'composite'
+  steps:
+    - id: detect
+      uses: actions/github-script@v8
+      env:
+        PATTERNS: ${{ inputs.patterns }}
+      with:
+        script: |
+          const DEFAULT_PATTERNS = [
+            String.raw`\.(js|mjs|cjs|ts|astro|md|mdx)$`,
+            String.raw`^(src|public)/`,
+            String.raw`^(astro|eslint|prettier|vitest)\.config(\.ts|\.mjs)?$`,
+            String.raw`^vitest\.setup\.ts$`,
+            String.raw`^tsconfig\.json$`,
+            String.raw`^package(-lock)?\.json$`,
+            String.raw`^\.github/(workflows|actions)/`,
+            String.raw`^\.tool-versions$`,
+          ];
+
+          if (context.eventName !== 'pull_request') {
+            core.info(`Event ${context.eventName}: running heavy work unconditionally.`);
+            core.setOutput('relevant', 'true');
+            return;
+          }
+
+          const raw = (process.env.PATTERNS || '').trim();
+          const sources = raw
+            ? raw.split('\n').map((s) => s.trim()).filter(Boolean)
+            : DEFAULT_PATTERNS;
+          const patterns = sources.map((s) => new RegExp(s));
+
+          const files = await github.paginate(github.rest.pulls.listFiles, {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.payload.pull_request.number,
+            per_page: 100,
+          });
+
+          const hit = files.find((f) => patterns.some((p) => p.test(f.filename)));
+          if (hit) {
+            core.info(`Relevant change detected: ${hit.filename}`);
+            core.setOutput('relevant', 'true');
+          } else {
+            core.info(`No relevant changes in ${files.length} files.`);
+            core.setOutput('relevant', 'false');
+          }

--- a/.github/workflows/code-codeql.yaml
+++ b/.github/workflows/code-codeql.yaml
@@ -11,6 +11,7 @@ on:
 permissions:
   actions: read
   contents: read
+  pull-requests: read
   security-events: write
 
 jobs:
@@ -31,11 +32,24 @@ jobs:
         #
         # COMPILED LANGUAGES (swift, c-cpp, java-kotlin, csharp) require a
         # build step BEFORE 'Perform CodeQL analysis' so the extractor can
-        # observe source compilation.
+        # observe source compilation. Example for Swift:
+        #
+        #   - name: Build (Swift)
+        #     if: matrix.language == 'swift'
+        #     run: |
+        #       sudo xcode-select -s /Applications/Xcode_16.3.app
+        #       xcodebuild build -project Your.xcodeproj -scheme Your \
+        #         -configuration Debug -destination 'platform=macOS' \
+        #         CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
         #
         # Each include entry registers its own status check, named
         # `analyze (<language>, <runner>)`. Update branch protection
-        # rulesets to require those exact contexts.
+        # rulesets to require those exact contexts. Keep this matrix
+        # free of extra keys — anything added here becomes part of the
+        # status check name and would break the required-check contexts.
+        # Per-language inputs to other steps (e.g. detect-relevant-
+        # changes patterns) are selected via `matrix.language` in those
+        # steps' expressions.
         include:
           - language: actions
             runner: ubuntu-latest
@@ -43,14 +57,25 @@ jobs:
             runner: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
+
+      - name: Detect relevant changes
+        id: changes
+        uses: ./.github/actions/detect-relevant-changes
+        with:
+          # 'actions' language only cares about workflow/action edits;
+          # 'javascript-typescript' falls back to the action's default
+          # JS/TS pattern set by passing an empty value.
+          patterns: ${{ matrix.language == 'actions' && '^\.github/(workflows|actions)/' || '' }}
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.35.5
+        if: steps.changes.outputs.relevant == 'true'
+        uses: github/codeql-action/init@v4.36.0
         with:
           languages: ${{ matrix.language }}
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v4.35.5
+        if: steps.changes.outputs.relevant == 'true'
+        uses: github/codeql-action/analyze@v4.36.0
         with:
           category: '/language:${{ matrix.language }}'

--- a/.github/workflows/code-lint.yaml
+++ b/.github/workflows/code-lint.yaml
@@ -4,21 +4,27 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout source code'
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
+
+      - name: 'Detect relevant changes'
+        id: changes
+        uses: ./.github/actions/detect-relevant-changes
 
       - name: 'Setup tools and dependencies'
+        if: steps.changes.outputs.relevant == 'true'
         uses: ./.github/actions/setup-tools
 
       - name: 'Check formatting'
-        if: always()
+        if: always() && steps.changes.outputs.relevant == 'true'
         run: npm run format
 
       - name: 'Check lint'
-        if: always()
+        if: always() && steps.changes.outputs.relevant == 'true'
         run: npm run lint

--- a/.github/workflows/code-test.yaml
+++ b/.github/workflows/code-test.yaml
@@ -4,22 +4,29 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout source code'
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
+
+      - name: 'Detect relevant changes'
+        id: changes
+        uses: ./.github/actions/detect-relevant-changes
 
       - name: 'Setup tools and dependencies'
+        if: steps.changes.outputs.relevant == 'true'
         uses: ./.github/actions/setup-tools
 
       - name: 'Run unit tests with coverage'
+        if: steps.changes.outputs.relevant == 'true'
         run: npm run test:coverage
 
       - name: 'Upload coverage report'
-        if: always()
+        if: always() && steps.changes.outputs.relevant == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: coverage

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -12,8 +12,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.changes.outputs.relevant }}
+    steps:
+      - name: 'Checkout source code'
+        uses: actions/checkout@v6.0.2
+
+      - name: 'Detect relevant changes'
+        id: changes
+        uses: ./.github/actions/detect-relevant-changes
+
   build:
-    if: github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]'
+    if: >
+      github.event.pull_request.head.repo.fork == false &&
+      github.actor != 'dependabot[bot]'
     permissions:
       contents: read
     uses: ./.github/workflows/code-build.yaml
@@ -26,8 +43,9 @@ jobs:
     if: >
       github.event.pull_request.head.repo.fork == false &&
       github.actor != 'dependabot[bot]' &&
-      !contains(github.event.pull_request.labels.*.name, 'no-deploy')
-    needs: build
+      !contains(github.event.pull_request.labels.*.name, 'no-deploy') &&
+      needs.detect-changes.outputs.relevant == 'true'
+    needs: [detect-changes, build]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -42,7 +60,7 @@ jobs:
 
     steps:
       - name: 'Checkout source code'
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: 'Setup tools'
         uses: ./.github/actions/setup-tools

--- a/.github/workflows/report-coverage.yaml
+++ b/.github/workflows/report-coverage.yaml
@@ -16,9 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout source code'
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: 'Download test coverage'
+        id: download
+        continue-on-error: true
         uses: actions/download-artifact@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -26,5 +28,10 @@ jobs:
           name: coverage
           path: coverage
 
+      - name: 'No coverage artifact'
+        if: steps.download.outcome != 'success'
+        run: echo "::notice::No coverage artifact found; nothing to report."
+
       - name: 'Report test coverage on pull request'
+        if: steps.download.outcome == 'success'
         uses: davelosert/vitest-coverage-report-action@v2.12.0

--- a/.github/workflows/report-licenses.yaml
+++ b/.github/workflows/report-licenses.yaml
@@ -9,13 +9,34 @@ permissions:
   pull-requests: write
 
 jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.changes.outputs.relevant }}
+    steps:
+      - name: 'Checkout source code'
+        uses: actions/checkout@v6.0.2
+
+      - name: 'Detect relevant changes'
+        id: changes
+        uses: ./.github/actions/detect-relevant-changes
+        with:
+          patterns: |
+            ^package(-lock)?\.json$
+
   license-report:
-    if: github.event.pull_request.head.repo.fork == false
+    needs: detect-changes
+    if: >
+      github.event.pull_request.head.repo.fork == false &&
+      needs.detect-changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
 
     steps:
       - name: 'Checkout source code'
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: 'Setup tools and dependencies'
         uses: ./.github/actions/setup-tools


### PR DESCRIPTION
## Summary

Syncs the `detect-relevant-changes` composite action from `richwklein/repo-template-astro` and wires it into all PR-triggered workflows. The action checks changed file paths on `pull_request` events and sets `relevant=true` only when files match a configurable pattern set, skipping heavy steps (npm install, builds, scans, deploys) on PRs that only touch content or untracked paths. On `push`, `schedule`, and `workflow_run` events it always returns `true`, so main-branch and scheduled runs are unaffected.

Also restores graceful artifact-missing handling in `report-coverage.yaml`, which had been lost in a prior sync.

## Linked issue

Closes #

## Type of change

_Put an `x` in the boxes that apply._

- [ ] Bug fix
- [ ] Feature
- [x] Maintenance / cleanup
- [ ] Documentation / content
- [ ] Breaking change

## Details

- **New:** `.github/actions/detect-relevant-changes/action.yaml` — composite action from the template; uses `actions/github-script` to paginate PR changed files and match against a configurable regex pattern list.
- **`code-lint.yaml`, `code-test.yaml`:** Added `pull-requests: read` permission (required by the action), pinned `actions/checkout` to `@v6.0.2`, added `detect-relevant-changes` step, and wrapped `setup-tools` / format / lint / test / upload steps with `if: steps.changes.outputs.relevant == 'true'`.
- **`code-codeql.yaml`:** Same treatment plus a per-language pattern so the `actions` matrix leg only re-runs on workflow/action file changes. Updated codeql-action `@v4.35.5` → `@v4.36.0`. Restored full matrix comments.
- **`deploy-preview.yaml`:** Added a `detect-changes` job. The `build` job (`build / Build` is a required check) still runs unconditionally to preserve required-check reporting. Only `deploy` and `lighthouse` are gated on `relevant == 'true'`, avoiding Netlify API calls and Lighthouse runs for content-only PRs.
- **`report-licenses.yaml`:** Added `detect-changes` job with a narrow `^package(-lock)?\.json$` pattern; license report only runs when dependency files change.
- **`report-coverage.yaml`:** Restored `continue-on-error: true`, the `No coverage artifact` notice step, and the `if: steps.download.outcome == 'success'` guard — needed because the test job now skips its artifact upload when no relevant changes are detected.

**Required-check safety:** `lint`, `test`, and both `analyze` checks are always satisfied because their jobs always run (only internal steps are conditional). `build / Build` is always satisfied because the `build` job in `deploy-preview.yaml` is not gated on relevance.

## Release / deploy impact

_Put an `x` in the boxes that apply._

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] This PR intentionally updates the version

## Validation

_Put an `x` in the boxes that apply._

- [ ] Lint passes locally
- [ ] Unit tests pass locally
- [ ] Added or updated tests where appropriate
- [x] Manually verified changes
- [ ] Documentation updated where appropriate

## Reviewer notes

`tag-release.yaml` intentionally has no guards: it fires on `push` to `main` only, and `detect-relevant-changes` returns `true` unconditionally for non-`pull_request` events. The heavy deploy/lighthouse chain is already gated by `needs.release-please.outputs.released == 'true'`.