### PR TITLE
chore(audit): sync PR templates, labeler workflow, and CI action pins with template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/bug.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bug.md
@@ -1,0 +1,36 @@
+## Summary
+
+Describe the bug being fixed and the impact of the fix.
+
+## Linked issue
+
+Closes #
+
+## Root cause
+
+What was wrong and why it produced the observed behavior.
+
+## Fix
+
+How the change addresses the root cause.
+
+## Validation
+
+_Put an `x` in the boxes that apply._
+
+- [ ] Lint passes locally
+- [ ] Unit tests pass locally
+- [ ] Added or updated a regression test
+- [ ] Manually verified the original bug no longer reproduces
+
+## Release / deploy impact
+
+_Put an `x` in the boxes that apply._
+
+- [ ] Preview deploy is useful for reviewing this change
+- [ ] Safe to label `no-deploy`
+- [ ] Breaking change (also apply the `breaking-change` label)
+
+## Reviewer notes
+
+Anything else that would help with review.

--- a/.github/PULL_REQUEST_TEMPLATE/documentation.md
+++ b/.github/PULL_REQUEST_TEMPLATE/documentation.md
@@ -1,0 +1,31 @@
+## Summary
+
+Describe the documentation or content change.
+
+## Linked issue
+
+Closes #
+
+## Scope
+
+What docs, pages, or content are updated.
+
+## Validation
+
+_Put an `x` in the boxes that apply._
+
+- [ ] Lint passes locally
+- [ ] Links checked
+- [ ] Rendered output reviewed (preview deploy or local build)
+- [ ] Spelling and grammar reviewed
+
+## Release / deploy impact
+
+_Put an `x` in the boxes that apply._
+
+- [ ] Preview deploy is useful for reviewing this change
+- [ ] Safe to label `no-deploy`
+
+## Reviewer notes
+
+Anything else worth highlighting.

--- a/.github/PULL_REQUEST_TEMPLATE/enhancement.md
+++ b/.github/PULL_REQUEST_TEMPLATE/enhancement.md
@@ -1,0 +1,37 @@
+## Summary
+
+Describe the new capability or improvement and why it exists.
+
+## Linked issue
+
+Closes #
+
+## Approach
+
+How the feature is implemented. Call out important tradeoffs or alternatives considered.
+
+## Out of scope
+
+What this PR deliberately does not include.
+
+## Validation
+
+_Put an `x` in the boxes that apply._
+
+- [ ] Lint passes locally
+- [ ] Unit tests pass locally
+- [ ] Added or updated tests covering the new behavior
+- [ ] Manually verified the new behavior
+- [ ] Documentation updated where appropriate
+
+## Release / deploy impact
+
+_Put an `x` in the boxes that apply._
+
+- [ ] Preview deploy is useful for reviewing this change
+- [ ] Safe to label `no-deploy`
+- [ ] Breaking change (also apply the `breaking-change` label)
+
+## Reviewer notes
+
+Follow-up work, screenshots, or anything else worth highlighting.

--- a/.github/PULL_REQUEST_TEMPLATE/task.md
+++ b/.github/PULL_REQUEST_TEMPLATE/task.md
@@ -1,0 +1,36 @@
+## Summary
+
+Describe the maintenance, cleanup, refactor, or process change.
+
+## Linked issue
+
+Closes #
+
+## Motivation
+
+What pain, risk, inconsistency, or gap this addresses.
+
+## Changes
+
+The notable changes in this PR.
+
+## Validation
+
+_Put an `x` in the boxes that apply._
+
+- [ ] Lint passes locally
+- [ ] Unit tests pass locally
+- [ ] Behavior is unchanged (refactor) or covered by existing/new tests
+- [ ] Manually verified where applicable
+
+## Release / deploy impact
+
+_Put an `x` in the boxes that apply._
+
+- [ ] Preview deploy is useful for reviewing this change
+- [ ] Safe to label `no-deploy`
+- [ ] Breaking change (also apply the `breaking-change` label)
+
+## Reviewer notes
+
+Anything else worth highlighting.

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,14 @@
+# Auto-applied PR labels by head-branch prefix.
+# See AGENTS.md for the branch-prefix convention.
+
+bug:
+  - head-branch: ['^(fix|bug|bugfix)-']
+
+enhancement:
+  - head-branch: ['^(feat|feature)-']
+
+task:
+  - head-branch: ['^(chore|refactor|test|build|ci|perf|style|task|maint|maintenance)-']
+
+documentation:
+  - head-branch: ['^(docs|doc)-']

--- a/.github/workflows/code-codeql.yaml
+++ b/.github/workflows/code-codeql.yaml
@@ -30,6 +30,13 @@ jobs:
         #   swift                       -> macos-latest
         #     (Swift extractor only runs on macOS)
         #
+        # PATH FILTERS: The detect-relevant-changes action defaults to
+        # .github/workflows/** and .github/actions/**. When adding a
+        # language entry here, pass the relevant source patterns via the
+        # `patterns` input so the job noop's when nothing important changed.
+        # Per-language pattern selection can be done inline:
+        #   patterns: ${{ matrix.language == 'actions' && '...' || '...' }}
+        #
         # COMPILED LANGUAGES (swift, c-cpp, java-kotlin, csharp) require a
         # build step BEFORE 'Perform CodeQL analysis' so the extractor can
         # observe source compilation. Example for Swift:
@@ -47,17 +54,18 @@ jobs:
         # rulesets to require those exact contexts. Keep this matrix
         # free of extra keys — anything added here becomes part of the
         # status check name and would break the required-check contexts.
-        # Per-language inputs to other steps (e.g. detect-relevant-
-        # changes patterns) are selected via `matrix.language` in those
-        # steps' expressions.
         include:
           - language: actions
             runner: ubuntu-latest
           - language: javascript-typescript
             runner: ubuntu-latest
     steps:
+      # Steps are conditionally skipped rather than the job, so the
+      # matrix-expanded status check (e.g. "analyze (actions, ubuntu-latest)")
+      # is always registered. A job-level skip leaves that check unreported,
+      # which blocks PRs that require it.
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
 
       - name: Detect relevant changes
         id: changes
@@ -70,12 +78,12 @@ jobs:
 
       - name: Initialize CodeQL
         if: steps.changes.outputs.relevant == 'true'
-        uses: github/codeql-action/init@v4.36.1
+        uses: github/codeql-action/init@v4.36.2
         with:
           languages: ${{ matrix.language }}
 
       - name: Perform CodeQL analysis
         if: steps.changes.outputs.relevant == 'true'
-        uses: github/codeql-action/analyze@v4.36.1
+        uses: github/codeql-action/analyze@v4.36.2
         with:
           category: '/language:${{ matrix.language }}'

--- a/.github/workflows/code-lint.yaml
+++ b/.github/workflows/code-lint.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout source code'
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
 
       - name: 'Detect relevant changes'
         id: changes

--- a/.github/workflows/code-test.yaml
+++ b/.github/workflows/code-test.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout source code'
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
 
       - name: 'Detect relevant changes'
         id: changes

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -1,0 +1,20 @@
+name: PR labeler
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    name: label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply labels from branch prefix
+        uses: actions/labeler@v6.1.0
+        with:
+          configuration-path: .github/labeler.yml
+          sync-labels: true

--- a/.github/workflows/report-coverage.yaml
+++ b/.github/workflows/report-coverage.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout source code'
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
 
       - name: 'Download test coverage'
         id: download


### PR DESCRIPTION
## Summary

Sync this repo with `richwklein/repo-template-astro` after running `/repo-template-audit`. Brings in missing PR templates, the auto-labeler workflow, and tightens a few CI action pins.

## Linked issue

Closes #

## Motivation

Drift accumulated against the template. This PR closes the non-pnpm gap so future audits stay focused on the in-flight pnpm migration.

## Changes

- Added PR templates: `.github/PULL_REQUEST_TEMPLATE/{bug,documentation,enhancement,task}.md`.
- Added `.github/labeler.yml` and `.github/workflows/pr-labeler.yaml` (auto-applies labels by branch prefix).
- Synced `.github/workflows/code-codeql.yaml`: restored the template's PATH FILTERS and job-vs-step skip rationale comments, bumped `github/codeql-action/init` to `v4.36.2` and `actions/checkout` to `v6.0.3`.
- Bumped `actions/checkout` to `v6.0.3` in `code-lint.yaml`, `code-test.yaml`, and `report-coverage.yaml`.

## Deferred (intentionally not in this PR)

- pnpm migration drift (`detect-relevant-changes`, `setup-tools`, `.prettierignore`, `.tool-versions`, `.vscode/launch.json`, `AGENTS.md`) — handled in a separate worktree.
- `code-build.yaml` — local `workflow_call` rewrite is intentional.
- `release-please.yaml` — superseded by the local `tag-release` workflow. Tracked via richwklein/repo-template-base#28 follow-up on action pinning policy.

## Validation

- [x] Lint passes locally (`npm run lint:fix`)
- [x] Format passes locally (`npm run format:fix`)
- [ ] Unit tests pass locally
- [x] Behavior is unchanged (refactor) or covered by existing/new tests

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)