### PR TITLE
fix(quote): add weekly quote for June 15, 2026

### DIFF
--- a/src/content/data/quote.json
+++ b/src/content/data/quote.json
@@ -1,5 +1,16 @@
 [
   {
+    "id": "e897f9db-af6b-422b-b383-f953b63bd1a6",
+    "text": "Nobody's free until everybody's free.",
+    "author": "Fannie Lou Hamer",
+    "chalked": "2026-06-15",
+    "source": {
+      "title": "Speech at the founding of the National Women's Political Caucus",
+      "type": "speech",
+      "year": 1971
+    }
+  },
+  {
     "id": "bdf23111-ef3a-40c2-8f7c-bf3cc291a3b9",
     "text": "It was June, and the world smelled of roses.",
     "author": "Maud Hart Lovelace",


### PR DESCRIPTION
## Summary

Add the weekly chalkboard quote for June 15, 2026. Picks a Juneteenth-themed quote ahead of Friday's holiday.

## Linked issue

Closes #

## Type of change

- [x] Documentation / content

## Details

Prepends a new entry to `src/content/data/quote.json`:

- **Quote:** "Nobody's free until everybody's free."
- **Author:** Fannie Lou Hamer
- **Source:** Speech at the founding of the National Women's Political Caucus (1971)
- **Chalked:** 2026-06-15

## Release / deploy impact

- [x] Preview deploy is useful for reviewing this change

## Validation

- [x] Lint passes locally
- [x] Unit tests pass locally
- [x] Manually verified changes

## Reviewer notes

release-please will cut the patch release from the `fix(quote):` commit on merge.