### PR TITLE
docs(agents): document branch prefixes and pr templates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,31 @@ Breaking changes: append `!` (e.g., `feat!: rename public API`) or include a `BR
 - Branches must be up to date with `main` before merging (strict status checks).
 - Commits must be signed.
 
+### Branch prefixes
+
+Name branches with a hyphen-delimited type prefix that mirrors the Conventional Commit type. The PR labeler workflow uses this prefix to apply the matching label automatically.
+
+| Prefix                                                                                                | Label           |
+| ----------------------------------------------------------------------------------------------------- | --------------- |
+| `feat-`, `feature-`                                                                                   | `enhancement`   |
+| `fix-`, `bug-`, `bugfix-`                                                                             | `bug`           |
+| `docs-`, `doc-`                                                                                       | `documentation` |
+| `chore-`, `refactor-`, `test-`, `build-`, `ci-`, `perf-`, `style-`, `task-`, `maint-`, `maintenance-` | `task`          |
+
+Example: `feature-add-search`, `fix-login-redirect`, `docs-readme-update`.
+
+## Pull requests
+
+This repo ships four PR templates aligned with the issue templates: `bug.md`, `enhancement.md`, `task.md`, `documentation.md` in `.github/PULL_REQUEST_TEMPLATE/`.
+
+Pick one by appending `?template=<name>.md` to the compare URL, for example:
+
+```text
+https://github.com/<owner>/<repo>/compare/main...<branch>?template=enhancement.md
+```
+
+Type labels (`bug`, `enhancement`, `task`, `documentation`) are applied automatically by the PR labeler workflow based on the branch prefix above. Apply `breaking-change` manually when a PR introduces a backwards-incompatible change.
+
 ## Required gates before merge
 
 - `lint` (eslint + prettier)


### PR DESCRIPTION
## Summary

Closes a documentation gap in `AGENTS.md`: `labeler.yml` references *"See AGENTS.md for the branch-prefix convention"* but the file does not include that section. Ports the Branch prefixes and Pull requests sections from `repo-template-base/AGENTS.md`.

## Linked issue

Closes #

## Scope

- `AGENTS.md` — add "Branch prefixes" subsection and "Pull requests" section.

## Validation

- [x] Lint passes locally
- [x] Links checked
- [x] Rendered output reviewed (preview deploy or local build)
- [x] Spelling and grammar reviewed

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label \`no-deploy\`

## Reviewer notes

Identified during a `/repo-template-audit` run. The same change is being upstreamed to `repo-template-astro` in a sibling PR so future template-generated repos pick it up automatically.