### PR TITLE
fix(ci): scope markdown change detection to src and public

### DIFF
--- a/.github/actions/detect-relevant-changes/action.yaml
+++ b/.github/actions/detect-relevant-changes/action.yaml
@@ -10,8 +10,9 @@ inputs:
     description: >
       Multi-line list of JavaScript-compatible regex patterns matched against
       the full path of each changed file. When empty, falls back to a default
-      set covering JS/TS/Astro source, Markdown, common configs, package
-      manifests, workflow/action edits, and .tool-versions.
+      set covering JS/TS/Astro source, any file under src/ or public/ (which
+      includes Markdown/MDX content), common configs, package manifests,
+      workflow/action edits, and .tool-versions.
     required: false
     default: ''
 
@@ -30,7 +31,7 @@ runs:
       with:
         script: |
           const DEFAULT_PATTERNS = [
-            String.raw`\.(js|mjs|cjs|ts|astro|md|mdx)$`,
+            String.raw`\.(js|mjs|cjs|ts|astro)$`,
             String.raw`^(src|public)/`,
             String.raw`^(astro|eslint|prettier|vitest)\.config(\.ts|\.mjs)?$`,
             String.raw`^vitest\.setup\.ts$`,


### PR DESCRIPTION
## Summary

The `detect-relevant-changes` action was matching any `*.md` or `*.mdx` file at any path, so docs-only PRs that touch top-level files like `AGENTS.md`, `README.md`, or `CHANGELOG.md` flagged as relevant and triggered the preview deploy plus lighthouse jobs. Observed on #964, which only modified `AGENTS.md`.

## Linked issue

Closes #

## Root cause

The first entry in the default pattern list was `\.(js|mjs|cjs|ts|astro|md|mdx)$` — it has no directory anchor, so every markdown file in the repo matched. The PR template's *Safe to label `no-deploy`* checkbox is informational only; it does not apply the label, so that gate also did not catch the case.

## Fix

Drop `md` and `mdx` from the top-level extension regex. Markdown and MDX content under `src/` or `public/` is still picked up by the existing `^(src|public)/` rule, so Astro content edits continue to trigger preview deploys. Updated the input description to reflect the narrower scope.

## Validation

- [x] Lint passes locally (n/a, YAML/JS in composite action, no source extension changed)
- [ ] Unit tests pass locally
- [ ] Added or updated a regression test
- [ ] Manually verified the original bug no longer reproduces

Will verify by watching this PR's own checks: it touches `.github/actions/...` which still matches `^\.github/(workflows|actions)/`, so deploy and lighthouse should still run on this PR (correct). A follow-up docs-only PR would be the true regression check.

## Release / deploy impact

- [x] Preview deploy is useful for reviewing this change
- [ ] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

This file is template-tracked via `repo-template-astro`. A follow-up PR will port the same change upstream so the `/repo-template-audit` drift resolves.