### PR TITLE
fix(quote): add weekly quote for June 22, 2026

### DIFF
--- a/src/content/data/quote.json
+++ b/src/content/data/quote.json
@@ -1,5 +1,11 @@
 [
   {
+    "id": "e1c4dfef-17aa-4dfc-83c5-86cc4e9935d4",
+    "text": "A journey is best measured in friends rather than miles.",
+    "author": "Tim Cahill",
+    "chalked": "2026-06-22"
+  },
+  {
     "id": "e897f9db-af6b-422b-b383-f953b63bd1a6",
     "text": "Nobody's free until everybody's free.",
     "author": "Fannie Lou Hamer",


### PR DESCRIPTION
## Summary

Adds the weekly chalkboard quote for the week of June 22, 2026.

> "A journey is best measured in friends rather than miles." — Tim Cahill

The entry is prepended to `src/content/data/quote.json` with a fresh UUID and `chalked: 2026-06-22`. The `source` object is omitted because the originating book could not be reliably verified across sources.

This week's theme: Jackson returning home from his two-week European school trip, a lake trip with our best friends, and the summer solstice.

## Validation

- [x] Lint passes locally
- [x] Unit tests pass locally
- [x] `pnpm run verify` (lint, format-check, tests, build) passes

## Release / deploy impact

- [x] Preview deploy is useful for reviewing this change

release-please will cut a patch release from the `fix(quote)` commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)