### PR TITLE
fix(quote): add weekly quote for June 29, 2026

### DIFF
--- a/src/content/data/quote.json
+++ b/src/content/data/quote.json
@@ -1,5 +1,16 @@
 [
   {
+    "id": "2a5420fc-a8ba-465e-859d-88ef632433e4",
+    "text": "Patriotism means to stand by the country. It does not mean to stand by the president.",
+    "author": "Theodore Roosevelt",
+    "chalked": "2026-06-29",
+    "source": {
+      "title": "Lincoln and Free Speech",
+      "type": "magazine",
+      "year": 1918
+    }
+  },
+  {
     "id": "e1c4dfef-17aa-4dfc-83c5-86cc4e9935d4",
     "text": "A journey is best measured in friends rather than miles.",
     "author": "Tim Cahill",


### PR DESCRIPTION
## Summary

Adds the weekly chalkboard quote for the week of June 29, 2026 (Fourth of July week), prepended to `src/content/data/quote.json`.

> "Patriotism means to stand by the country. It does not mean to stand by the president."
> — Theodore Roosevelt, *Lincoln and Free Speech* (Metropolitan Magazine, 1918)

The abbreviated, chalkboard-friendly form of Roosevelt's opening line, verified against Quote Investigator and Snopes.

## Fix

Prepended a new quote object (id, text, author, `chalked: 2026-06-29`, `magazine` source). `package.json` untouched; release-please cuts the patch release from the `fix(quote)` commit.

## Validation

- [x] Lint passes locally
- [x] Unit tests pass locally

> Note: `pnpm run build` could not complete locally. Astro's font step failed fetching a Noto Sans Georgian `.woff2` from `cdn.jsdelivr.net` (HTTP 503), a transient CDN outage unrelated to this content-only change. CI should build cleanly once jsDelivr recovers.

## Release / deploy impact

- [x] Preview deploy is useful for reviewing this change