### PR TITLE
fix(quote): add weekly quote for July 6, 2026

### DIFF
--- a/src/content/data/quote.json
+++ b/src/content/data/quote.json
@@ -1,5 +1,16 @@
 [
   {
+    "id": "3463cad1-b35e-486d-9d0e-320351abff9d",
+    "text": "We hold these truths to be self-evident, that all men are created equal.",
+    "author": "Thomas Jefferson",
+    "chalked": "2026-07-06",
+    "source": {
+      "title": "Declaration of Independence",
+      "type": "other",
+      "year": 1776
+    }
+  },
+  {
     "id": "2a5420fc-a8ba-465e-859d-88ef632433e4",
     "text": "Patriotism means to stand by the country. It does not mean to stand by the president.",
     "author": "Theodore Roosevelt",


### PR DESCRIPTION
## Summary

Adds the weekly chalkboard quote for the week of July 6, 2026. The theme, chosen by my youngest, is "Equality" for the week following the 4th of July weekend.

> "We hold these truths to be self-evident, that all men are created equal." — Thomas Jefferson, Declaration of Independence, 1776

## Linked issue

N/A — recurring weekly content update.

## Root cause

N/A — not a bug fix; the `fix` type is used so release-please cuts a patch release for the content change.

## Fix

Prepends the new entry to `src/content/data/quote.json` with a generated UUID, `chalked` date of 2026-07-06, and a `source` object (`type: other`, year 1776).

## Validation

_Put an `x` in the boxes that apply._

- [x] Lint passes locally
- [x] Unit tests pass locally
- [ ] Added or updated a regression test
- [ ] Manually verified the original bug no longer reproduces

## Release / deploy impact

_Put an `x` in the boxes that apply._

- [x] Preview deploy is useful for reviewing this change
- [ ] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

`pnpm run verify` (lint, format check, tests, build) passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)