### PR TITLE
fix(quote): add weekly quote for July 13, 2026

### DIFF
--- a/src/content/data/quote.json
+++ b/src/content/data/quote.json
@@ -1,5 +1,16 @@
 [
   {
+    "id": "a80f5044-98f8-4190-a8c5-10ba35859ace",
+    "text": "You can't stop the waves, but you can learn to surf.",
+    "author": "Jon Kabat-Zinn",
+    "chalked": "2026-07-13",
+    "source": {
+      "title": "Wherever You Go, There You Are",
+      "type": "book",
+      "year": 1994
+    }
+  },
+  {
     "id": "3463cad1-b35e-486d-9d0e-320351abff9d",
     "text": "We hold these truths to be self-evident, that all men are created equal.",
     "author": "Thomas Jefferson",


### PR DESCRIPTION
## Summary

Adds the weekly chalkboard quote for the week of July 13, 2026: "You can't stop the waves, but you can learn to surf." by Jon Kabat-Zinn, from *Wherever You Go, There You Are* (1994).

## Linked issue

None. This is the routine weekly quote update.

## Root cause

The chalkboard quote for the week of July 13, 2026 was not yet present in `src/content/data/quote.json`.

## Fix

Prepends a new entry to `quote.json` with a generated UUID, the quote text, author, `chalked` date of 2026-07-13, and a book source citation. release-please will cut the patch release from the squash-merged commit.

## Validation

_Put an `x` in the boxes that apply._

- [x] Lint passes locally
- [x] Unit tests pass locally
- [ ] Added or updated a regression test
- [ ] Manually verified the original bug no longer reproduces

`pnpm run verify` (lint, format check, tests, build) passed locally: 262 tests passed, build completed.

## Release / deploy impact

_Put an `x` in the boxes that apply._

- [x] Preview deploy is useful for reviewing this change
- [ ] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

Data-only change, no code touched. The quote is not a duplicate of any existing entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)