### PR TITLE
fix(quote): add weekly quote for July 20, 2026

### DIFF
--- a/src/content/data/quote.json
+++ b/src/content/data/quote.json
@@ -1,5 +1,16 @@
 [
   {
+    "id": "6b2b1aa6-2605-4968-bcae-5bd55a9d321e",
+    "text": "Begin at the beginning and go on till you come to the end; then stop.",
+    "author": "Lewis Carroll",
+    "chalked": "2026-07-20",
+    "source": {
+      "title": "Alice's Adventures in Wonderland",
+      "type": "book",
+      "year": 1865
+    }
+  },
+  {
     "id": "a80f5044-98f8-4190-a8c5-10ba35859ace",
     "text": "You can't stop the waves, but you can learn to surf.",
     "author": "Jon Kabat-Zinn",


### PR DESCRIPTION
## Summary

Adds the weekly chalkboard quote for July 20, 2026.

## Linked issue

N/A

## Root cause

No quote entry existed for the week of July 20, 2026.

## Fix

Prepended a new entry to `src/content/data/quote.json`:

> "Begin at the beginning and go on till you come to the end; then stop." — Lewis Carroll, *Alice's Adventures in Wonderland* (1865)

## Validation

- [x] Lint passes locally
- [x] Unit tests pass locally
- [ ] Added or updated a regression test
- [x] Manually verified the original bug no longer reproduces

## Release / deploy impact

- [x] Preview deploy is useful for reviewing this change
- [ ] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

Quote chosen to fit the week's theme: back from a long lake weekend, county fair starting, kids working, easing back into the week's rhythm.