### PR TITLE
fix(quote): add weekly quote for July 27, 2026

### DIFF
--- a/src/content/data/quote.json
+++ b/src/content/data/quote.json
@@ -1,5 +1,11 @@
 [
   {
+    "id": "318b913f-6807-4911-9abb-027239116a71",
+    "text": "Time stands still best in moments that look suspiciously like ordinary life.",
+    "author": "Brian Andreas",
+    "chalked": "2026-07-27"
+  },
+  {
     "id": "6b2b1aa6-2605-4968-bcae-5bd55a9d321e",
     "text": "Begin at the beginning and go on till you come to the end; then stop.",
     "author": "Lewis Carroll",


### PR DESCRIPTION
## Summary

Adds this week's chalkboard quote to `src/content/data/quote.json`, prepended as the newest entry:

> "Time stands still best in moments that look suspiciously like ordinary life." — Brian Andreas

This is the routine weekly quote update, not a behavioral bug fix — the `fix(quote)` commit type is the repo's established convention so release-please cuts a patch release.

## Linked issue

N/A — no tracked issue for this routine content update.

## Root cause

N/A — not a bug fix.

## Fix

Prepended a new quote entry (with generated UUID and today's `chalked` date) to the front of the JSON array, per the `weekly-quote` skill workflow.

## Validation

- [x] Lint passes locally (`pnpm run lint:fix`)
- [x] Unit tests pass locally (`pnpm run verify`, includes vitest)
- [ ] Added or updated a regression test
- [ ] Manually verified the original bug no longer reproduces

`pnpm run verify` (lint + format-check + tests + build) ran clean end to end.

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

Source citation was left off intentionally — the quote is widely attributed to Brian Andreas' StoryPeople work, but the exact original print/book couldn't be confirmed with confidence.
