### PR TITLE
chore(audit): sync files with template

### DIFF
--- a/.github/workflows/code-codeql.yaml
+++ b/.github/workflows/code-codeql.yaml
@@ -78,12 +78,12 @@ jobs:
 
       - name: Initialize CodeQL
         if: steps.changes.outputs.relevant == 'true'
-        uses: github/codeql-action/init@v4.37.0
+        uses: github/codeql-action/init@v4.37.1
         with:
           languages: ${{ matrix.language }}
 
       - name: Perform CodeQL analysis
         if: steps.changes.outputs.relevant == 'true'
-        uses: github/codeql-action/analyze@v4.37.0
+        uses: github/codeql-action/analyze@v4.37.1
         with:
           category: '/language:${{ matrix.language }}'

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Apply labels from branch prefix
-        uses: actions/labeler@v6
+        uses: actions/labeler@v7
         with:
           configuration-path: .github/labeler.yml
           sync-labels: true

--- a/.github/workflows/report-coverage.yaml
+++ b/.github/workflows/report-coverage.yaml
@@ -34,4 +34,4 @@ jobs:
 
       - name: 'Report test coverage on pull request'
         if: steps.download.outcome == 'success'
-        uses: davelosert/vitest-coverage-report-action@v2.12.1
+        uses: davelosert/vitest-coverage-report-action@v2.12.2

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-nodejs 22.21.0
+nodejs 22.22.3
 pnpm 10.24.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,11 +26,11 @@ pnpm run verify
 
 ## Commits
 
-Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages. release-please parses these to generate changelogs and version bumps.
+Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages. The release workflow (release-please) parses these to generate changelogs and version bumps.
 
 Allowed types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `build`, `ci`, `perf`, `style`.
 
-Breaking changes: append `!` (e.g., `feat!: rename public API`) or include a `BREAKING CHANGE:` footer.
+Breaking changes: append `!` after the type (e.g., `feat!: rename public API`) or add a `BREAKING CHANGE:` footer.
 
 ## Release versioning
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,7 +9,19 @@
       "include-component-in-tag": false,
       "bump-minor-pre-major": false,
       "draft": false,
-      "prerelease": false
+      "prerelease": false,
+      "changelog-sections": [
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "perf", "section": "Performance Improvements" },
+        { "type": "refactor", "section": "Code Refactoring" },
+        { "type": "docs", "section": "Documentation" },
+        { "type": "build", "section": "Build System", "hidden": true },
+        { "type": "ci", "section": "Continuous Integration", "hidden": true },
+        { "type": "test", "section": "Tests", "hidden": true },
+        { "type": "style", "section": "Styles", "hidden": true },
+        { "type": "chore", "section": "Miscellaneous Chores" }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

Sync template-tracked files with `richwklein/repo-template-astro` after a template drift audit.

## Linked issue

N/A

## Motivation

Routine template drift audit surfaced several files that had fallen behind the upstream template. Bringing them back in line keeps CI, toolchain, and release config consistent with the template baseline.

## Changes

- `.github/workflows/code-codeql.yaml`: codeql-action `v4.37.0 → v4.37.1`
- `.github/workflows/pr-labeler.yaml`: actions/labeler `v6 → v7`
- `.github/workflows/report-coverage.yaml`: vitest-coverage-report-action `v2.12.1 → v2.12.2`
- `.tool-versions`: Node `22.21.0 → 22.22.3`
- `AGENTS.md`: commits-section wording refinements from template
- `release-please-config.json`: adopt the template's `changelog-sections` block (local `package-name` and `bump-minor-pre-major` preserved)

Intentionally kept local (project-specific, not synced): `.vscode/launch.json`, `.vscode/settings.json`, `.gitignore`, `.vscode/extensions.json`, `vitest.config.ts`, `pnpm-lock.yaml`, and the seven extra repo labels.

## Validation

- [x] Lint passes locally
- [ ] Unit tests pass locally
- [ ] Behavior is unchanged (refactor) or covered by existing/new tests
- [ ] Manually verified where applicable

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

Changes limited to CI workflow action versions, toolchain pin, agent docs, and release changelog config. No application source or site content touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)