### PR TITLE
fix: correct quotes page rendering in dark mode

### DIFF
--- a/src/components/QuoteCard.astro
+++ b/src/components/QuoteCard.astro
@@ -25,16 +25,16 @@ const source = quote.data.source
 
 <div
   class:list={[
-    'rounded-md border border-stone-300 bg-gray-50 text-stone-900',
+    'border-stroke-light bg-card-light text-fg-light rounded-md border',
     'flex h-full min-h-40 flex-col justify-between p-6',
     className,
   ]}
 >
   <figure>
     <blockquote class:list={['text-2xl leading-tight']}>{quote.data.text}</blockquote>
-    <figcaption class="mt-3 text-sm text-stone-700">
+    <figcaption class="text-fg-main mt-3 text-sm">
       <div class="flex flex-wrap items-center gap-2">
-        <span class="text-base text-stone-800">
+        <span class="text-fg-light text-base">
           &mdash;&nbsp;{quote.data.author}
           {
             source && (
@@ -47,7 +47,7 @@ const source = quote.data.source
         </span>
         {
           source && (
-            <span class="inline-flex items-center gap-1 rounded-full bg-stone-200 px-3 py-1 text-[11px] font-semibold tracking-wide text-stone-700 uppercase">
+            <span class="bg-card-dark text-fg-main inline-flex items-center gap-1 rounded-full px-3 py-1 text-[11px] font-semibold tracking-wide uppercase">
               <QuoteSourceIcon type={source.type} />
               {source.year ?? '—'}
             </span>

--- a/src/pages/quote/index.astro
+++ b/src/pages/quote/index.astro
@@ -27,9 +27,9 @@ const path = '/quote'
   </Fragment>
   <BreadcrumbHeader head={{ name: 'Quotes', path: path }} class:list={['mb-4']} />
   <article>
-    <div class:list={['prose max-w-none', 'md:prose-lg lg:prose-xl']}>
+    <div class:list={['prose dark:prose-invert max-w-none', 'md:prose-lg lg:prose-xl']}>
       {
-        "When Rachel first hung a chalkboard in our kitchen, it quickly became my favorite canvas. Before long, I took on the task of updating it, sharing a new quote at the start of each week. Each message reflects a moment in time—what we've recently experienced or what's just around the corner for our family. This virtual chalkboard is a collection of those quotes, capturing the essence of our journey together."
+        "When Rachel first hung a chalkboard in our kitchen, it quickly became my favorite canvas. Before long, I took on the task of updating it, sharing a new quote at the start of each week. Each message reflects a moment in time: what we've recently experienced or what's just around the corner for our family. This virtual chalkboard is a collection of those quotes, capturing the essence of our journey together."
       }
     </div>
     <QuoteGrid quotes={quotes} class:list={['mt-4']} />


### PR DESCRIPTION
## Summary

The quotes page rendered poorly in dark mode. Quote cards stayed white against the dark background, and the intro paragraph rendered dark-on-dark, making it nearly unreadable.

## Linked issue

Closes #

## Root cause

- `QuoteCard` used hardcoded light Tailwind colors (`border-stone-300 bg-gray-50 text-stone-900`, plus stone text and pill shades) with no dark-mode handling, so the cards never adapted to the dark theme.
- The intro paragraph on `quote/index.astro` used `prose` without `dark:prose-invert`, so its text kept the default dark typography color on the dark page.

## Fix

- Swap the `QuoteCard` colors for the semantic tokens already used by `ArticleCard` (`border-stroke-light`, `bg-card-light`, `text-fg-light`, `text-fg-main`, `bg-card-dark`), which flip automatically under `.dark`.
- Add `dark:prose-invert` to the intro paragraph so its text inverts in dark mode, matching the article page.
- Replace the em dash in the intro copy with a colon.

## Validation

- [x] Lint passes locally
- [x] Unit tests pass locally
- [ ] Added or updated a regression test
- [ ] Manually verified the original bug no longer reproduces

## Release / deploy impact

- [x] Preview deploy is useful for reviewing this change
- [ ] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

Purely presentational. The card colors now reuse the same semantic tokens as `ArticleCard`, so they stay consistent with the rest of the site in both themes. A dark-mode preview deploy is the easiest way to confirm.