### PR TITLE
feat: add collection page structured data

### DIFF
--- a/src/components/seo/CollectionJson.astro
+++ b/src/components/seo/CollectionJson.astro
@@ -1,0 +1,50 @@
+---
+/**
+ * @name CollectionJson
+ * Component used to build out an ld+json CollectionPage with an item list of
+ * the entries shown on a collection page such as a category, tag, archive, or
+ * author listing.
+ *
+ * @return {Function} an Astro component factory function.
+ *
+ * @example
+ * <CollectionJson name="Code" path="/category/code" items={items} site={site} />
+ */
+import { buildUrl } from '@utils/misc'
+import type { CollectionEntry } from 'astro:content'
+
+interface Props {
+  name: string
+  path: string
+  items: {
+    name: string
+    path: string
+  }[]
+  site: CollectionEntry<'site'>
+}
+
+const { name, path, items, site } = Astro.props
+---
+
+<script
+  is:inline
+  type="application/ld+json"
+  set:html={JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name: name,
+    url: buildUrl(path, site.data.origin),
+    mainEntity: {
+      '@type': 'ItemList',
+      numberOfItems: items.length,
+      itemListElement: items.map((item, index) => {
+        return {
+          '@type': 'ListItem',
+          position: index + 1,
+          name: item.name,
+          url: buildUrl(item.path, site.data.origin),
+        }
+      }),
+    },
+  })}
+/>

--- a/src/pages/article/archive-[page].astro
+++ b/src/pages/article/archive-[page].astro
@@ -6,6 +6,7 @@ import ArticleGrid from '@components/ArticleGrid.astro'
 import BreadcrumbHeader from '@components/BreadcrumbHeader.astro'
 import Pagniation from '@components/Pagniation.astro'
 import BreadcrumbJson from '@components/seo/BreadcrumbJson.astro'
+import CollectionJson from '@components/seo/CollectionJson.astro'
 import SeoBasic from '@components/seo/SeoBasic.astro'
 import Layout from '@layouts/Layout.astro'
 import { getArticles } from '@utils/article'
@@ -44,6 +45,15 @@ const path = `/article/archive-${page.currentPage}`
         { name: 'Articles', path: '/article' },
         { name: `Archive ${page.currentPage}`, path: path },
       ]}
+    />
+    <CollectionJson
+      name={`Archive ${page.currentPage}`}
+      path={path}
+      items={page.data.map((article) => ({
+        name: article.data.title,
+        path: `/article/${article.id}`,
+      }))}
+      site={site}
     />
   </Fragment>
   <BreadcrumbHeader

--- a/src/pages/author/[id].astro
+++ b/src/pages/author/[id].astro
@@ -9,6 +9,7 @@ import DisplayLimitAlert from '@components/DisplayLimitAlert.astro'
 import ResponsiveImage from '@components/ResponsiveImage.astro'
 import AuthorJson from '@components/seo/AuthorJson.astro'
 import BreadcrumbJson from '@components/seo/BreadcrumbJson.astro'
+import CollectionJson from '@components/seo/CollectionJson.astro'
 import OpenGraphProfile from '@components/seo/OpenGraphProfile.astro'
 import SeoBasic from '@components/seo/SeoBasic.astro'
 import SocialBar from '@components/SocialBar.astro'
@@ -61,6 +62,15 @@ const { articles, total } = await getArticlesByAuthor(author.id, limit)
         { name: 'Authors', path: '/author' },
         { name: data.name, path: path },
       ]}
+    />
+    <CollectionJson
+      name={`Articles by ${data.name}`}
+      path={path}
+      items={articles.map((article) => ({
+        name: article.data.title,
+        path: `/article/${article.id}`,
+      }))}
+      site={site}
     />
   </Fragment>
   <BreadcrumbHeader

--- a/src/pages/category/[id].astro
+++ b/src/pages/category/[id].astro
@@ -7,6 +7,7 @@ import BackLink from '@components/BackLink.astro'
 import BreadcrumbHeader from '@components/BreadcrumbHeader.astro'
 import DisplayLimitAlert from '@components/DisplayLimitAlert.astro'
 import BreadcrumbJson from '@components/seo/BreadcrumbJson.astro'
+import CollectionJson from '@components/seo/CollectionJson.astro'
 import SeoBasic from '@components/seo/SeoBasic.astro'
 import Layout from '@layouts/Layout.astro'
 import slugify from '@sindresorhus/slugify'
@@ -55,6 +56,15 @@ const { articles, total } = await getArticlesByCategory(category, limit)
         { name: 'Categories', path: '/category' },
         { name: category, path: path },
       ]}
+    />
+    <CollectionJson
+      name={category}
+      path={path}
+      items={articles.map((article) => ({
+        name: article.data.title,
+        path: `/article/${article.id}`,
+      }))}
+      site={site}
     />
   </Fragment>
   <BreadcrumbHeader

--- a/src/pages/tag/[id].astro
+++ b/src/pages/tag/[id].astro
@@ -7,6 +7,7 @@ import BackLink from '@components/BackLink.astro'
 import BreadcrumbHeader from '@components/BreadcrumbHeader.astro'
 import DisplayLimitAlert from '@components/DisplayLimitAlert.astro'
 import BreadcrumbJson from '@components/seo/BreadcrumbJson.astro'
+import CollectionJson from '@components/seo/CollectionJson.astro'
 import SeoBasic from '@components/seo/SeoBasic.astro'
 import Layout from '@layouts/Layout.astro'
 import slugify from '@sindresorhus/slugify'
@@ -56,6 +57,15 @@ const { articles, total } = await getArticlesByTag(tag, limit)
         { name: 'Tags', path: '/tag' },
         { name: tag, path: path },
       ]}
+    />
+    <CollectionJson
+      name={tag}
+      path={path}
+      items={articles.map((article) => ({
+        name: article.data.title,
+        path: `/article/${article.id}`,
+      }))}
+      site={site}
     />
   </Fragment>
   <BreadcrumbHeader head={{ name: 'Tags', path: '/tag' }} tail={tag} class:list={['mb-4']} />

--- a/test/components/seo/CollectionJson.test.ts
+++ b/test/components/seo/CollectionJson.test.ts
@@ -1,0 +1,60 @@
+import CollectionJson from '@components/seo/CollectionJson.astro'
+import { getDefaultSite } from '@utils/site'
+import { experimental_AstroContainer as AstroContainer } from 'astro/container'
+import type { CollectionEntry } from 'astro:content'
+import { beforeAll, describe, expect, test } from 'vitest'
+
+describe('collectionJson', () => {
+  let site: CollectionEntry<'site'>
+  let linkedData: string
+
+  beforeAll(async () => {
+    site = await getDefaultSite()
+    linkedData = await render()
+  })
+
+  const render = async () => {
+    const container = await AstroContainer.create()
+    return await container.renderToString(CollectionJson, {
+      props: {
+        name: 'Code',
+        path: '/category/code',
+        items: [
+          { name: 'First Article', path: '/article/first' },
+          { name: 'Second Article', path: '/article/second' },
+        ],
+        site: site,
+      },
+    })
+  }
+
+  test('that it contains an ld+json', async () => {
+    expect(linkedData).toContain('<script type="application/ld+json">')
+  })
+
+  test('that it contains a collection page', async () => {
+    expect(linkedData).toContain('"@type":"CollectionPage"')
+  })
+
+  test('that it names the collection and links to its url', async () => {
+    expect(linkedData).toContain('"name":"Code"')
+    expect(linkedData).toContain('"url":"http://localhost:4321/category/code"')
+  })
+
+  test('that it contains an item list with the number of items shown', async () => {
+    expect(linkedData).toContain('"@type":"ItemList"')
+    expect(linkedData).toContain('"numberOfItems":2')
+  })
+
+  test('that it lists the first entry', async () => {
+    expect(linkedData).toContain(
+      '"position":1,"name":"First Article","url":"http://localhost:4321/article/first"'
+    )
+  })
+
+  test('that it lists the second entry', async () => {
+    expect(linkedData).toContain(
+      '"position":2,"name":"Second Article","url":"http://localhost:4321/article/second"'
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Collection-style pages (categories, tags, archive, and per-author article listings) act as curated lists of entries but had no structured data describing them as collections. This adds `CollectionPage` JSON-LD with an item list so those pages are machine-readable as collections, complementing the existing article, site, breadcrumb, and author-profile structured data.

## Linked issue

Closes #628

## Approach

- New `src/components/seo/CollectionJson.astro`, built in the same style as the other `*Json.astro` SEO components. It emits a `CollectionPage` whose `mainEntity` is an `ItemList` of `ListItem` entries (position, name, absolute URL via `buildUrl`), with `numberOfItems` reflecting the entries shown on the page.
- Generic `{ name, path, items[], site }` props so the same component serves both article listings and any future entry list.
- Wired into `category/[id]`, `tag/[id]`, `article/archive-[page]`, and `author/[id]`, alongside the existing breadcrumb (and, on the author page, `ProfilePage`) JSON-LD.
- `ListItem` entries reference each article by name and URL rather than inlining full `BlogPosting` objects, per the issue's first-pass scope.

## Out of scope

- IndieWeb protocol features (IndieAuth, Micropub, Webmention) tracked separately in #750.
- Reworking existing article/site/breadcrumb/author structured data.
- Replacing `ListItem` with full inline `BlogPosting` objects.

## Validation

- [x] Lint passes locally
- [x] Unit tests pass locally
- [x] Added or updated tests covering the new behavior
- [x] Manually verified the new behavior
- [ ] Documentation updated where appropriate

Manually verified the built `dist/` HTML for a category, tag, archive, and author page emits valid `CollectionPage` + `ItemList` markup with absolute URLs, and that existing breadcrumb/profile JSON-LD still renders. `schema.org` and Google rich-results validation still to be run against a preview URL.

## Release / deploy impact

- [x] Preview deploy is useful for reviewing this change
- [ ] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

"author collection pages" is implemented as the per-author article listing (`author/[id]`), not the author index. Follow-up: run the schema.org validator and Google rich-results test against the preview deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)