### PR TITLE
fix(quote): add weekly quote for August 3, 2026

### DIFF
--- a/content/data/quote.json
+++ b/content/data/quote.json
@@ -1,5 +1,16 @@
 [
   {
+    "id": "4186339a-36e4-42ce-acc8-bc5dcffa8dc1",
+    "text": "All children, except one, grow up.",
+    "author": "J.M. Barrie",
+    "chalked": "2026-08-03",
+    "source": {
+      "title": "Peter Pan",
+      "type": "book",
+      "year": 1911
+    }
+  },
+  {
     "id": "318b913f-6807-4911-9abb-027239116a71",
     "text": "Time stands still best in moments that look suspiciously like ordinary life.",
     "author": "Brian Andreas",


### PR DESCRIPTION
## Summary

Adds the weekly chalkboard quote for August 3, 2026. The `fix(quote)` type triggers release-please to cut a patch release that publishes the new quote.

> "All children, except one, grow up." — J.M. Barrie, *Peter Pan* (1911)

## Linked issue

None. Routine weekly content update.

## Root cause

N/A. This is a scheduled content addition, not a defect fix.

## Fix

Prepends a new entry to `content/data/quote.json` with a fresh UUID, `chalked` date `2026-08-03`, and a `source` object for the book citation.

## Validation

_Put an `x` in the boxes that apply._

- [x] Lint passes locally
- [x] Unit tests pass locally
- [ ] Added or updated a regression test
- [x] Manually verified the original bug no longer reproduces

`pnpm run verify` passed: lint, format-check, 268 tests, and a clean build.

## Release / deploy impact

_Put an `x` in the boxes that apply._

- [x] Preview deploy is useful for reviewing this change
- [ ] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

Quote checked against `quote.json` for duplicates. Near-theme entries (Fred Rogers on transitions, the Dalai Lama roots/wings) were intentionally avoided.